### PR TITLE
Fixed package.json and tsconfig.json conflict

### DIFF
--- a/previewhtml-sample/package.json
+++ b/previewhtml-sample/package.json
@@ -26,7 +26,7 @@
 	"activationEvents": [
 		"onCommand:extension.showCssPropertyPreview"
 	],
-	"main": "./out/src/extension",
+	"main": "./out/extension",
 	"contributes": {
 		"commands": [
 			{


### PR DESCRIPTION
In package.json, 'main' is set as 'out/src/extension' whereas in tsconfig.json, 'outDir' is set as 'out' which causes runtime errors. 
package.json 'main' parameter is changed to 'out/extension' to prevent those errors.  