### PR TITLE
Fixes in launch.json files needed due to recent change in task property convention

### DIFF
--- a/lsp-multi-root-sample/.vscode/launch.json
+++ b/lsp-multi-root-sample/.vscode/launch.json
@@ -11,7 +11,7 @@
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/client/out/src/**/*.js" ],
-			"preLaunchTask": "Client Watch"
+			"preLaunchTask": "watch:client"
 		},
 		{
 			"name": "Attach to Server",
@@ -20,7 +20,7 @@
 			"port": 6009,
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/client/server/**/*.js" ],
-			"preLaunchTask": "Server Watch"
+			"preLaunchTask": "watch:server"
 		}
 	]
 }

--- a/lsp-multi-server-sample/.vscode/launch.json
+++ b/lsp-multi-server-sample/.vscode/launch.json
@@ -11,7 +11,7 @@
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/client/out/src/**/*.js" ],
-			"preLaunchTask": "Client Watch"
+			"preLaunchTask": "watch:client"
 		},
 		{
 			"name": "Attach to Server",
@@ -20,7 +20,7 @@
 			"port": 6010,
 			"sourceMaps": true,
 			"outFiles": [ "${workspaceRoot}/client/server/**/*.js" ],
-			"preLaunchTask": "Server Watch"
+			"preLaunchTask": "watch:server"
 		}
 	]
 }

--- a/lsp-sample/.vscode/launch.json
+++ b/lsp-sample/.vscode/launch.json
@@ -15,7 +15,7 @@
 			"outFiles": [
 				"${workspaceRoot}/client/out/**/*.js"
 			],
-			"preLaunchTask": "Client Watch"
+			"preLaunchTask": "watch:client"
 		},
 		{
 			"name": "Attach to Server",
@@ -27,7 +27,7 @@
 				"${workspaceRoot}/client/server/**/*.js"
 			],
 			"protocol": "legacy",
-			"preLaunchTask": "Server Watch"
+			"preLaunchTask": "watch:server"
 		}
 	]
 }


### PR DESCRIPTION
taskName deprecated; using labels instead ==> renaming preLaunchTask was needed.