### PR TITLE
Removed dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ list of self-contained, running extensions that show one or multiple concepts of
 
 * [Virtual Documents](/contentprovider-sample/README.md)
 * [Editor Decoration](/decorator-sample/README.md)
-* [Language Provider](/languageprovider-sample/README.md)
 * [Preview Html](/previewhtml-sample/README.md)
 * [Status Bar](/statusbar-sample/README.md)
 * [Theme](/theme-sample)


### PR DESCRIPTION
There exists no longer a extension example for a language provider.