### PR TITLE
Fix tree view sample

### DIFF
--- a/tree-view-sample/README.md
+++ b/tree-view-sample/README.md
@@ -6,7 +6,7 @@
 
 ## Running the example
 
-- Open this example in VS Code
+- Open this example in VS Code Insiders
 - `npm install`
 - `npm run compile`
 - `F5` to start debugging

--- a/tree-view-sample/package.json
+++ b/tree-view-sample/package.json
@@ -7,6 +7,7 @@
 	"engines": {
 		"vscode": "^1.20.0"
 	},
+	"enableProposedApi": true,
 	"categories": [
 		"Other"
 	],

--- a/tree-view-sample/vscode.proposed.d.ts
+++ b/tree-view-sample/vscode.proposed.d.ts
@@ -639,3 +639,4 @@ declare module 'vscode' {
 		getParent?(element: T): ProviderResult<T>;
 
 	}
+}


### PR DESCRIPTION
The tree-view sample had a compilation error due a missing brace in `vscode.proposed.d.ts`

This PR
- [x] Corrects the missing brace
- [x] Adds `enableProposedApi ` to `package.json`; enabling the project to run in debug mode.
- [x] Adds a specific mention to VS Code Insiders in the Readme.