### PR TITLE
Update npm scripts

### DIFF
--- a/lsp-sample/client/package.json
+++ b/lsp-sample/client/package.json
@@ -45,9 +45,9 @@
 		}
 	},
 	"scripts": {
-		"vscode:prepublish": "tsc -p ./",
-		"compile": "tsc -p ./",
-		"watch": "tsc -w -p ./",
+		"vscode:prepublish": "../node_modules/.bin/tsc -p ./",
+		"compile": "../node_modules/.bin/tsc -p ./",
+		"watch": "../node_modules/.bin/tsc -w -p ./",
 		"update-vscode": "node ./node_modules/vscode/bin/install",
 		"postinstall": "node ./node_modules/vscode/bin/install"
 	},

--- a/lsp-sample/package.json
+++ b/lsp-sample/package.json
@@ -11,11 +11,11 @@
 	},
 	"scripts": {
 		"postinstall": "cd server && npm install && cd ../client && npm install && cd ..",
-		"compile": "tsc -p client/tsconfig.json && cd server && npm run installServer && cd .. && tsc -p server/tsconfig.json",
+		"compile": "tsc -p server/tsconfig.json && tsc -p client/tsconfig.json",
 		"compile:client": "tsc -p client/tsconfig.json",
 		"watch:client": "tsc -w -p client/tsconfig.json",
-		"compile:server": "cd server && npm run installServer && cd .. && tsc -p server/tsconfig.json",
-		"watch:server": "cd server && npm run installServer && cd .. && tsc -w -p server/tsconfig.json"
+		"compile:server": "tsc -p server/tsconfig.json",
+		"watch:server": "tsc -w -p server/tsconfig.json"
 	},
 	"devDependencies": {
 		"@types/mocha": "^2.2.48",

--- a/lsp-sample/server/package.json
+++ b/lsp-sample/server/package.json
@@ -15,8 +15,7 @@
 		"vscode-languageserver": "^3.5.0"
 	},
 	"scripts": {
-		"installServer": "installServerIntoExtension ../client ./package.json ./tsconfig.json",
-		"compile": "installServerIntoExtension ../client ./package.json ./tsconfig.json && tsc -p .",
-		"watch": "installServerIntoExtension ../client ./package.json ./tsconfig.json && tsc -w -p ."
+		"compile": "../node_modules/.bin/tsc -p .",
+		"watch": "../node_modules/.bin/tsc -w -p ."
 	}
 }


### PR DESCRIPTION
This PR updates the build scripts for the LSP sample. The original scripts don't work for me. `installServerIntoExtension` does not exists. Also, I was unable to manually compile or watch in the individual  directories.

(I used https://github.com/kieferrm/lsp-dev-setup to setup an experimentation environment that covers the LSP SKD as well as the samples.)