### PR TITLE
Change `client` folder to `lsp-sample`

### DIFF
--- a/lsp-sample/README.md
+++ b/lsp-sample/README.md
@@ -15,7 +15,7 @@ The language server is located in the 'server' folder.
 # How to run locally
 * `npm install` to initialize the extension and the server
 * `npm run compile` to compile the extension and the server
-* open the `client` folder in VS Code. In the Debug viewlet, run 'Launch Client' from drop-down to launch the extension and attach to the extension.
+* open the `lsp-sample` folder in VS Code. In the Debug viewlet, run 'Launch Client' from drop-down to launch the extension and attach to the extension.
 * create a file `test.txt`, and type `typescript`. You should see a validation error.
 * to debug the server use the 'Attach to Server' launch config.
 * set breakpoints in the client or the server.


### PR DESCRIPTION
There is no `.vscode` folder inside the `client` folder that holds some launch configration. The parent directory contains a `.vscode` with a `launch.json` which defines 'Launch Client'.