### PR TITLE
Distinguish between watch and compile

### DIFF
--- a/webview-sample/README.md
+++ b/webview-sample/README.md
@@ -15,7 +15,7 @@ Demonstrates VS Code's [webview API](https://code.visualstudio.com/docs/extensio
 
 - Open this example in VS Code 1.23+
 - `npm install`
-- `npm run compile`
+- `npm run watch` or `npm run compile`
 - `F5` to start debugging
 
 Run the `Cat Coding: Start cat coding session` to create the webview.

--- a/webview-sample/package.json
+++ b/webview-sample/package.json
@@ -30,7 +30,8 @@
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
-    "compile": "tsc -watch -p ./",
+    "compile": "tsc -p ./",
+    "watch": "tsc -w -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "dependencies": {


### PR DESCRIPTION
When testing #48453. For running `npm run compile` people would not expect a running watch compile.