### PR TITLE
Change the dependsOn labels for the 'watch' task

### DIFF
--- a/lsp-multi-server-sample/.vscode/tasks.json
+++ b/lsp-multi-server-sample/.vscode/tasks.json
@@ -37,8 +37,8 @@
 		{
 			"label": "watch",
 			"dependsOn": [
-				"watch:client",
-				"watch:server"
+				"npm: watch:client",
+				"npm: watch:server"
 			],
 			"group": {
 				"kind": "build",

--- a/lsp-sample/.vscode/tasks.json
+++ b/lsp-sample/.vscode/tasks.json
@@ -36,8 +36,8 @@
 		{
 			"label": "watch",
 			"dependsOn": [
-				"watch:client",
-				"watch:server"
+				"npm: watch:client",
+				"npm: watch:server"
 			],
 			"group": {
 				"kind": "build",


### PR DESCRIPTION
Because the task signatures have been changed to `npm: <task_name>`, the `dependsOn` calls needed to change as well. Fixes #75 