### PR TITLE
Add a compound launch config to lsp-sample

### DIFF
--- a/lsp-sample/.vscode/launch.json
+++ b/lsp-sample/.vscode/launch.json
@@ -37,5 +37,11 @@
 			"sourceMaps": true,
 			"outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
 		}
+	],
+	"compounds": [
+		{
+			"name": "Client + Server",
+			"configurations": ["Launch Client", "Attach to Server"]
+		}
 	]
 }

--- a/lsp-sample/server/src/server.ts
+++ b/lsp-sample/server/src/server.ts
@@ -35,10 +35,10 @@ connection.onInitialize((params: InitializeParams) => {
 	return {
 		capabilities: {
 			textDocumentSync: documents.syncKind,
-            // Tell the client that the server supports code completion
-            completionProvider: {
-                resolveProvider: true
-            }
+			// Tell the client that the server supports code completion
+			completionProvider: {
+				resolveProvider: true
+			}
 		}
 	}
 });


### PR DESCRIPTION
A LSP implementation with client + server seems like the ideal use case for a compound launch config (I use it all the time when working on the Haxe extension / language server at least), so it seems like a good idea to include one here.

Also fixed some inconsistent indentation.