### PR TITLE
simplify vscode-install call

### DIFF
--- a/lsp-sample/client/package.json
+++ b/lsp-sample/client/package.json
@@ -13,8 +13,8 @@
 		"vscode": "^1.23.0"
 	},
 	"scripts": {
-		"update-vscode": "node ./node_modules/vscode/bin/install",
-		"postinstall": "node ./node_modules/vscode/bin/install"
+		"update-vscode": "vscode-install",
+		"postinstall": "vscode-install"
 	},
 	"dependencies": {
 		"vscode": "^1.1.18",


### PR DESCRIPTION
When I use `lsp-sample` as a starting point I sometimes switch my package managers. It would be more robust to directly run `vscode-install` here instead of using a path, because depending on your package manager the path to the bin could be slightly different. 👍