### PR TITLE
Fix typo in package.json of tree-view-sample

### DIFF
--- a/tree-view-sample/package.json
+++ b/tree-view-sample/package.json
@@ -171,7 +171,7 @@
 					"group": "inline"
 				},
 				{
-					"command": "nodeDependencies.deletentry",
+					"command": "nodeDependencies.deleteEntry",
 					"when": "view == nodeDependencies && viewItem == dependency"
 				},
 				{


### PR DESCRIPTION
This fixes a small typo in the `package.json` file where the `Delete Entry` menu item was pointing to a invalid command.