### PR TITLE
clarify how to remove decorations for a decoration type from view

### DIFF
--- a/decorator-sample/USAGE.md
+++ b/decorator-sample/USAGE.md
@@ -68,3 +68,5 @@ activeEditor.setDecorations(smallNumberDecorationType, smallNumbers);
 ## Tips
 
 As a note, if you insert a new range of decorations using `editor.setDecorations` with a `TextEditorDecorationType` that has already been used, it will overwrite the previous set of decorations.
+
+If you'd like to remove a decoration type then pass in an empty array to clear it from the editor. Example: `editor.setDecorations(decorationType, []);`

--- a/decorator-sample/USAGE.md
+++ b/decorator-sample/USAGE.md
@@ -69,4 +69,4 @@ activeEditor.setDecorations(smallNumberDecorationType, smallNumbers);
 
 As a note, if you insert a new range of decorations using `editor.setDecorations` with a `TextEditorDecorationType` that has already been used, it will overwrite the previous set of decorations.
 
-If you'd like to remove a decoration type then pass in an empty array to clear it from the editor. Example: `editor.setDecorations(decorationType, []);`
+If you'd like to remove a decoration(s) of a certain decoration type then pass in an empty array to clear it from the editor. Example: `editor.setDecorations(decorationType, []);`


### PR DESCRIPTION
It was not very clear that I should use the `.setDecorations()` function to remove previously added decorations of a certain decoration type. I updated the note so that others may understand that usage is available and how to do it themselves.