### PR TITLE
Fix path to task-provider-sample's main

### DIFF
--- a/task-provider-sample/package.json
+++ b/task-provider-sample/package.json
@@ -13,7 +13,7 @@
 	"activationEvents": [
 		"onCommand:workbench.action.tasks.runTask"
 	],
-	"main": "./out/src/extension",
+	"main": "./out/extension",
 	"contributes": {
 		"taskDefinitions": [
 			{


### PR DESCRIPTION
It's built to out/extension.js, so launching the extension currently produces an error. I guess that was caused by this change:

https://github.com/Microsoft/vscode-extension-samples/commit/704f351abdcd509279cef358afa720b1e6c6961f#diff-71ee4bf336efb1f169e66d21bbc6d508