### PR TITLE
Fix focus issue with multi-step quick input sample

### DIFF
--- a/quickinput-sample/src/multiStepInput.ts
+++ b/quickinput-sample/src/multiStepInput.ts
@@ -239,7 +239,7 @@ class MultiStepInput {
 					this.current.dispose();
 				}
 				this.current = input;
-				this.current.show();
+				setTimeout(() => input.show(), 5);
 			});
 		} finally {
 			disposables.forEach(d => d.dispose());
@@ -298,7 +298,7 @@ class MultiStepInput {
 					this.current.dispose();
 				}
 				this.current = input;
-				this.current.show();
+				setTimeout(() => input.show(), 5);
 			});
 		} finally {
 			disposables.forEach(d => d.dispose());


### PR DESCRIPTION
This should fix the issue found in #164 where some focus stealing is causing subsequent inputs to hide immediately after being shown.