### PR TITLE
Fix extension path

### DIFF
--- a/configuration-sample/package.json
+++ b/configuration-sample/package.json
@@ -15,7 +15,7 @@
 		"onCommand:config.commands.configureEmptyLastLineCurrentFile",
 		"onCommand:config.commands.configureEmptyLastLineFiles"
 	],
-	"main": "./out/src/extension",
+	"main": "./out/extension",
 	"keywords": [
 		"multi-root ready"
 	],


### PR DESCRIPTION
This pull request fixes the path to the compiled extension.

Curiously the [`./out/extension`](https://github.com/microsoft/vscode-extension-samples/search?q=%22%2Fout%2Fextension%22&unscoped_q=%22%2Fsrc%2Fout%2Fextension%22) path is used far more than the [`./out/src/extension`](https://github.com/microsoft/vscode-extension-samples/search?q="%2Fout%2Fsrc%2Fextension"&unscoped_q="%2Fout%2Fsrc%2Fextension") path.