### PR TITLE
disable other extensions when testing

### DIFF
--- a/helloworld-test-sample/.vscode/launch.json
+++ b/helloworld-test-sample/.vscode/launch.json
@@ -20,6 +20,7 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
+				"--disable-extensions",
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
 			],


### PR DESCRIPTION
Very likely no reason to run other extensions when testing and they slow down the tests.