### PR TITLE
Fix path to 'extension.ts'

### DIFF
--- a/helloworld-test-sample/src/test/suite/extension.test.ts
+++ b/helloworld-test-sample/src/test/suite/extension.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../extension';
+// import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');


### PR DESCRIPTION
The default location for `extension.ts` is two levels up, not one.