### PR TITLE
Test explorer integration

### DIFF
--- a/helloworld-test-sample/.vscode/settings.json
+++ b/helloworld-test-sample/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "debug.node.autoAttach": "on"
+  "debug.node.autoAttach": "on",
+  "mochaExplorer.files": "out/test/suite/*.test.js",
+  "mochaExplorer.ui": "tdd",
+  "mochaExplorer.launcherScript": "node_modules/mocha-explorer-launcher-scripts/vscode-test",
+  "mochaExplorer.autoload": false,
+  "mochaExplorer.ipcRole": "server",
+  "mochaExplorer.env": {
+    "VSCODE_VERSION": "insiders",
+    "ELECTRON_RUN_AS_NODE": null
+  }
 }

--- a/helloworld-test-sample/README.md
+++ b/helloworld-test-sample/README.md
@@ -14,3 +14,10 @@ You can find the accompanying documentation at https://code.visualstudio.com/api
 - Run the `Run Extension Tests` target in the Debug View. This will:
 	- Start a task `npm: watch` to compile the code
 	- Run the extension integration test in a new VS Code window
+
+## Running the tests in Mocha Test Explorer
+
+- Run the extension tests as described above to ensure that the initial setup (including downloading a copy of VS Code, which may take some time) is completed
+- Open the Test Explorer view
+- Click the reload button
+- Click the run button

--- a/helloworld-test-sample/package-lock.json
+++ b/helloworld-test-sample/package-lock.json
@@ -5,22 +5,28 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "^7.8.3"
 			}
 		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+			"dev": true
+		},
 		"@babel/highlight": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
 			"dev": true,
 			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.0",
 				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
 			}
 		},
@@ -54,9 +60,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "8.10.48",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.48.tgz",
-			"integrity": "sha512-c35YEBTkL4rzXY2ucpSKy+UYHjUBIIkuJbWYbsGIrKLEWU5dgJMmLkkIb3qeC3O3Tpb1ZQCwecscvJTDjDjkRw==",
+			"version": "12.12.38",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.38.tgz",
+			"integrity": "sha512-75eLjX0pFuTcUXnnWmALMzzkYorjND0ezNEycaKesbUBg9eGZp4GHPuDmkRc4mQQvIpe29zrzATNRA6hkYqwmA==",
 			"dev": true
 		},
 		"@types/vscode": {
@@ -199,9 +205,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
 		"concat-map": {
@@ -318,12 +324,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
 		},
 		"execa": {
@@ -693,6 +693,15 @@
 				}
 			}
 		},
+		"mocha-explorer-launcher-scripts": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/mocha-explorer-launcher-scripts/-/mocha-explorer-launcher-scripts-0.1.0.tgz",
+			"integrity": "sha512-FVp/N7ERYFXA2v4JOAvNackItJWafXL9cfg0rQIAOkuwPuFv+r2vlJajcPc1hLXUvsKYZRDLFm9g+f9VTeDaPw==",
+			"dev": true,
+			"requires": {
+				"vscode-test-adapter-remoting-util": "^0.9.0"
+			}
+		},
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -867,9 +876,9 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-			"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
@@ -933,6 +942,15 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -979,31 +997,45 @@
 				"has-flag": "^3.0.0"
 			}
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
+			"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
 			"dev": true
 		},
 		"tslint": {
-			"version": "5.16.0",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
-			"integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
 				"chalk": "^2.3.0",
 				"commander": "^2.12.1",
-				"diff": "^3.2.0",
+				"diff": "^4.0.1",
 				"glob": "^7.1.1",
-				"js-yaml": "^3.13.0",
+				"js-yaml": "^3.13.1",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"resolve": "^1.3.2",
 				"semver": "^5.3.0",
 				"tslib": "^1.8.0",
 				"tsutils": "^2.29.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
+				}
 			}
 		},
 		"tsutils": {
@@ -1016,9 +1048,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"vscode-test": {
@@ -1030,6 +1062,23 @@
 				"http-proxy-agent": "^2.1.0",
 				"https-proxy-agent": "^2.2.4",
 				"rimraf": "^2.6.3"
+			}
+		},
+		"vscode-test-adapter-api": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/vscode-test-adapter-api/-/vscode-test-adapter-api-1.8.0.tgz",
+			"integrity": "sha512-sNSxc2ec0JHl7PACebJwg/Ew/3FiAXBndHDS4Zp27l893wdIyhSeZL9y7j57YV6dDUkNnaRg2QcyIIBvlk8obw==",
+			"dev": true
+		},
+		"vscode-test-adapter-remoting-util": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/vscode-test-adapter-remoting-util/-/vscode-test-adapter-remoting-util-0.9.0.tgz",
+			"integrity": "sha512-py1QHTAduaoj+pJy08f5au00AbfGttu8jXvUPTDW8N2wMGXI6JoUXhoRaix6CJH6B/lRQOTVZpBCWHBWMUB0ug==",
+			"dev": true,
+			"requires": {
+				"split": "^1.0.1",
+				"tslib": "^1.11.1",
+				"vscode-test-adapter-api": "^1.8.0"
 			}
 		},
 		"which": {

--- a/helloworld-test-sample/package.json
+++ b/helloworld-test-sample/package.json
@@ -38,6 +38,7 @@
 		"@types/vscode": "^1.32.0",
 		"glob": "^7.1.4",
 		"mocha": "^6.1.4",
+		"mocha-explorer-launcher-scripts": "^0.1.0",
 		"source-map-support": "^0.5.12",
 		"tslint": "^5.19.0",
 		"typescript": "^3.8.3",


### PR DESCRIPTION
The latest version of the Mocha Test Explorer extension supports `vscode-test`. This PR adds the necessary dependency and settings to `helloworld-test-sample` to show the tests in Test Explorer.