### PR TITLE
Update mocha types to match library version

### DIFF
--- a/lsp-sample/client/src/test/index.ts
+++ b/lsp-sample/client/src/test/index.ts
@@ -10,8 +10,8 @@ export function run(): Promise<void> {
 	// Create the mocha test
 	const mocha = new Mocha({
 		ui: 'tdd',
+		color: true,
 	});
-	mocha.useColors(true);
 	mocha.timeout(100000);
 
 	const testsRoot = __dirname;

--- a/lsp-sample/package-lock.json
+++ b/lsp-sample/package-lock.json
@@ -49,9 +49,9 @@
 			"dev": true
 		},
 		"@types/mocha": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-			"integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.2.tgz",
+			"integrity": "sha512-5cv8rmqT3KX9XtWDvSgGYfS4OwrKM2eei90GWLnTYz+AXRiBv5uYcKBjnkQ4katNvfYk3+o2bHGZUsDhdcoUyg==",
 			"dev": true
 		},
 		"@types/node": {

--- a/lsp-sample/package.json
+++ b/lsp-sample/package.json
@@ -53,7 +53,7 @@
 		"test": "sh ./scripts/e2e.sh"
 	},
 	"devDependencies": {
-		"@types/mocha": "^7.0.2",
+		"@types/mocha": "^8.0.2",
 		"mocha": "^8.0.1",
 		"@types/node": "^12.12.0",
 		"eslint": "^6.4.0",


### PR DESCRIPTION
E2E test is failing currently because mocha removed useColors method. Mocha has colors method, but I can't see it in types, so I changed it to settings option.
https://mochajs.org/api/mocha#useColors