### PR TITLE
Add @types/node to webview-sample

### DIFF
--- a/webview-sample/package-lock.json
+++ b/webview-sample/package-lock.json
@@ -48,6 +48,12 @@
 			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
 			"dev": true
 		},
+		"@types/node": {
+			"version": "12.19.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.3.tgz",
+			"integrity": "sha512-8Jduo8wvvwDzEVJCOvS/G6sgilOLvvhn1eMmK3TW8/T217O7u1jdrK6ImKLv80tVryaPSVeKu6sjDEiFjd4/eg==",
+			"dev": true
+		},
 		"@types/vscode": {
 			"version": "1.47.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",

--- a/webview-sample/package.json
+++ b/webview-sample/package.json
@@ -45,6 +45,7 @@
 		"@typescript-eslint/parser": "^3.0.2",
 		"eslint": "^7.1.0",
 		"typescript": "^4.0.2",
-		"@types/vscode": "^1.47.0"
+		"@types/vscode": "^1.47.0",
+		"@types/node": "^12.12.0"
 	}
 }


### PR DESCRIPTION
Add `@types/node` to `webview-sample` to fix the following compile error:

```
$ npm run compile

> cat-coding@0.0.1 compile /Users/tamura/src/github/vscode-extension-samples/webview-sample
> tsc -p ./

src/extension.ts:28:5 - error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the `lib` compiler option to include 'dom'.

28  			console.log(`Got state: ${state}`);
    			~~~~~~~


Found 1 error.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! cat-coding@0.0.1 compile: `tsc -p ./`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the cat-coding@0.0.1 compile script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/tamura/.npm/_logs/2020-11-02T07_09_57_981Z-debug.log
````

