### PR TITLE
i18n-sample: remove the note about nls.coreLanguages

### DIFF
--- a/i18n-sample/gulpfile.js
+++ b/i18n-sample/gulpfile.js
@@ -21,7 +21,6 @@ const inlineMap = true;
 const inlineSource = false;
 const outDest = 'out';
 
-// If all VS Code langaues are support you can use nls.coreLanguages
 const languages = [{ folderName: 'jpn', id: 'ja' }];
 
 const cleanTask = function() {


### PR DESCRIPTION
The export was removed here:
https://github.com/microsoft/vscode-nls-dev/commit/ee7ad9f3684ef6376b37cc116e6f11b6d812c40f#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL171

Actually, it would be nice to have the whole example updated, I'm not sure whether the rest of it is relevant.