### PR TITLE
Fix webview sample deserializing after an extension update

### DIFF
--- a/webview-sample/src/extension.ts
+++ b/webview-sample/src/extension.ts
@@ -26,10 +26,22 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.registerWebviewPanelSerializer(CatCodingPanel.viewType, {
 			async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, state: any) {
 				console.log(`Got state: ${state}`);
+				// Reset the webview options so we use latest uri for `localResourceRoots`.
+				webviewPanel.webview.options = getWebviewOptions(context.extensionUri);
 				CatCodingPanel.revive(webviewPanel, context.extensionUri);
 			}
 		});
 	}
+}
+
+function getWebviewOptions(extensionUri: vscode.Uri): vscode.WebviewOptions {
+	return {
+		// Enable javascript in the webview
+		enableScripts: true,
+
+		// And restrict the webview to only loading content from our extension's `media` directory.
+		localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'media')]
+	};
 }
 
 /**
@@ -63,13 +75,7 @@ class CatCodingPanel {
 			CatCodingPanel.viewType,
 			'Cat Coding',
 			column || vscode.ViewColumn.One,
-			{
-				// Enable javascript in the webview
-				enableScripts: true,
-
-				// And restrict the webview to only loading content from our extension's `media` directory.
-				localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'media')]
-			}
+			getWebviewOptions(extensionUri),
 		);
 
 		CatCodingPanel.currentPanel = new CatCodingPanel(panel, extensionUri);


### PR DESCRIPTION
Issue: webviews that get deserialized will use `localResourceRoots` from the deserialized extension version.  This means if the extension gets updated by the marketplace, the deserialized webview will use the wrong localResourceRoot by default, causing the deserialized version to fail to load any resources.

If you set the `panel.webview.options` during the deserialize, you can override it to the new resource roots.

Since this is a sample that others would copy, it seems like good practice to make it clear that extensions which deserialize and limit localResourceRoots should do this. A more involved extension could use this to change their internal build structure but still work across updates.

More context: I put a PR to vscode  (https://github.com/microsoft/vscode/pull/114661) to fix this on the platform side, but it was suggested to do this as an extension-level workaround instead.

**How to test this:** (a bit involved, we need to simulate an extension update)
1. Build the cat-coding webview sample extension
2. Copy the package.json, out, media dirs into a new folder called sample-version1. The package.json has version 0.0.1.
3. Move this into a folder somewhere called test-ext-dir.
4. Launch vscode with that as the extensions dir: code --extensions-dir=/path/to/test-ext-dir
5. Open the webview (cmd-shift-p "cat coding")
6. Close vscode
7. Rebuild cat-coding webview with this patch applied, copy it to sample-version2 (keep both versions in the extensions dir)
8. Relaunch vscode again with the same ext-dir.
9. without this patch, it would fail to load the js file in the webview (the count would stay at 0). But with the patch, it's able to load the javascript and start counting.