### PR TITLE
fix #392 test-provider-sample: operator is always displayed as '+'

### DIFF
--- a/test-provider-sample/src/testProvider.ts
+++ b/test-provider-sample/src/testProvider.ts
@@ -210,7 +210,7 @@ class TestCase extends vscode.TestItem {
     public generation: number,
     public readonly parent: TestHeading | TestFile,
   ) {
-    super(`markdown/${location.uri.toString()}/${a} + ${b} = ${expected}`, `${a} + ${b} = ${expected}`, false);
+    super(`markdown/${location.uri.toString()}/${a} ${operator} ${b} = ${expected}`, `${a} ${operator} ${b} = ${expected}`, false);
   }
 
   async run(): Promise<vscode.TestState> {


### PR DESCRIPTION
This PR fixes #392

Result:
![image](https://user-images.githubusercontent.com/6726799/112150988-9db4ca00-8bd8-11eb-9367-98bc8c4309d6.png)

/assign @connor4312 
