### PR TITLE
[i18n-sample]: Bumped up `engines.vscode` and `@types/vscode`.

### DIFF
--- a/i18n-sample/README.md
+++ b/i18n-sample/README.md
@@ -16,7 +16,7 @@ This folder contains a sample VS code extension that shows how to use the packag
 
 ## Running the Sample
 
-Localization values are only applied when running the gulp `build` task. During normally development which uses `tsc -watch` to compile no localization post processing happends. This speeds up development time.
+Localization values are only applied when running the gulp `build` task. During normally development which uses `tsc -watch` to compile no localization post processing happens. This speeds up development time.
 
 1. Ensure that you have `gulp-cli` installed globally using `npm install --global gulp-cli`.
 1. Run `npm install` to bring in the dependencies.

--- a/i18n-sample/gulpfile.js
+++ b/i18n-sample/gulpfile.js
@@ -21,7 +21,7 @@ const inlineMap = true;
 const inlineSource = false;
 const outDest = 'out';
 
-// If all VS Code langaues are support you can use nls.coreLanguages
+// If all VS Code languages are support you can use nls.coreLanguages
 const languages = [{ folderName: 'jpn', id: 'ja' }];
 
 const cleanTask = function() {

--- a/i18n-sample/package-lock.json
+++ b/i18n-sample/package-lock.json
@@ -188,9 +188,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.34.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.34.0.tgz",
-			"integrity": "sha512-t81rGr6aFw8TMap7UJdikC5ilOtL0yNr/pkovyyTy31fZ4XJehrxLMRh8nJuoOF3+g4rG9ljmtQo7tm6wyoaYA==",
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
+			"integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/i18n-sample/package.json
+++ b/i18n-sample/package.json
@@ -7,7 +7,7 @@
 	"version": "0.1.0",
 	"publisher": "vscode-i18n-sample",
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.55.0"
 	},
 	"categories": [
 		"Other"
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^12.12.0",
-		"@types/vscode": "^1.34.0",
+		"@types/vscode": "^1.55.0",
 		"@typescript-eslint/eslint-plugin": "^4.16.0",
 		"@typescript-eslint/parser": "^4.16.0",
 		"del": "^4.1.1",


### PR DESCRIPTION
 - Use `1.55.0` so that the `gulp package` does not fail.
 - Fixed typo.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

Before the changes:
```sh
i18n-sample % gulp package
[09:43:41] Using gulpfile ~/git/vscode-extension-samples/i18n-sample/gulpfile.js
[09:43:41] Starting 'package'...
[09:43:41] Starting 'cleanTask'...
[09:43:41] Finished 'cleanTask' after 11 ms
[09:43:41] Starting 'internalNlsCompileTask'...
[09:43:43] Finished 'internalNlsCompileTask' after 1.8 s
[09:43:43] Starting 'addI18nTask'...
[09:43:43] Finished 'addI18nTask' after 8.69 ms
[09:43:43] Starting 'vscePackageTask'...
[09:43:43] 'vscePackageTask' errored after 5.38 ms
[09:43:43] Error: @types/vscode ^1.34.0 greater than engines.vscode ^1.32.0. Consider upgrade engines.vscode or use an older @types/vscode version
    at Object.validateVSCodeTypesCompatibility (/Users/akos.kitta/git/vscode-extension-samples/i18n-sample/node_modules/vsce/out/validation.js:85:19)
    at validateManifest (/Users/akos.kitta/git/vscode-extension-samples/i18n-sample/node_modules/vsce/out/package.js:632:22)
    at async Promise.all (index 0)
[09:43:43] 'package' errored after 1.83 s
```

After the changes:
```sh
i18n-sample % gulp package
[09:47:25] Using gulpfile ~/git/vscode-extension-samples/i18n-sample/gulpfile.js
[09:47:25] Starting 'package'...
[09:47:25] Starting 'cleanTask'...
[09:47:25] Finished 'cleanTask' after 12 ms
[09:47:25] Starting 'internalNlsCompileTask'...
[09:47:26] Finished 'internalNlsCompileTask' after 1.78 s
[09:47:26] Starting 'addI18nTask'...
[09:47:27] Finished 'addI18nTask' after 9.09 ms
[09:47:27] Starting 'vscePackageTask'...
 DONE  Packaged: /Users/akos.kitta/git/vscode-extension-samples/i18n-sample/i18n-sample-0.1.0.vsix (25 files, 6.52MB)
[09:47:29] Finished 'vscePackageTask' after 2.61 s
[09:47:29] Finished 'package' after 4.42 s
```

----

Thank you for the great examples ❤️ 