### PR TITLE
Remove extra parseTree

### DIFF
--- a/tree-view-sample/src/jsonOutline.ts
+++ b/tree-view-sample/src/jsonOutline.ts
@@ -15,7 +15,6 @@ export class JsonOutlineProvider implements vscode.TreeDataProvider<number> {
 	constructor(private context: vscode.ExtensionContext) {
 		vscode.window.onDidChangeActiveTextEditor(() => this.onActiveEditorChanged());
 		vscode.workspace.onDidChangeTextDocument(e => this.onDocumentChanged(e));
-		this.parseTree();
 		this.autoRefresh = vscode.workspace.getConfiguration('jsonOutline').get('autorefresh');
 		vscode.workspace.onDidChangeConfiguration(() => {
 			this.autoRefresh = vscode.workspace.getConfiguration('jsonOutline').get('autorefresh');


### PR DESCRIPTION
Hello,
I think this call to `parseTree` is unnecessary, because line 23 runs `onActiveEditorChanged()`, which runs `refresh()`, which runs `parseTree`.

Let me know your thoughts, thanks!