### PR TITLE
Fix broken link to LICENSE in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ You need to have [node](https://nodejs.org/en/) and [npm](https://nodejs.org/en/
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the [MIT](https://github.com/Microsoft/vscode-extension-samples/blob/ext-docs/LICENSE) License.
+Licensed under the [MIT](https://github.com/microsoft/vscode-extension-samples/blob/main/LICENSE) License.


### PR DESCRIPTION
The current link to the license file seems broken. This new link should work 😃 

(PS: This samples repository is super helpful—thank you, maintainers!)