### PR TITLE
Use new API in 'Getting Started Sample'

### DIFF
--- a/getting-started-sample/package.json
+++ b/getting-started-sample/package.json
@@ -19,11 +19,18 @@
 	],
 	"main": "./out/extension.js",
 	"contributes": {
-		"startEntries": [
+		"menus": {
+			"file/newFile": [
+				{
+					"command": "getting-started-sample.sayHello"
+				}
+			]
+		},
+		"commands":[
 			{
 				"category": "file",
-				"command": "getting-started-sample.sayHello",
-				"title": "Say Hello"
+				"title": "Say Hello",
+				"command": "getting-started-sample.sayHello"
 			}
 		],
 		"walkthroughs": [


### PR DESCRIPTION
`startEntries` contribution point is now removed in favour of `file/newFile` menu contribution point, as demonstrated by the hint

![Screenshot 2021-08-12 at 19 30 56](https://user-images.githubusercontent.com/287584/129249912-d5e1f4dd-7867-479f-80da-900b712af5ba.png)
