### PR TITLE
Fix code/cd typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You need to have [node](https://nodejs.org/en/) and [npm](https://nodejs.org/en/
 ## Usage
 
 - `git clone https://github.com/Microsoft/vscode-extension-samples`
-- `cd vscode-extension-sample`
+- `cd vscode-extension-samples`
 - `cd <any-sample-folder>`
 - `npm install` in the terminal, then `F5` to run the sample
 - Alternatively, follow the instructions in each sample's README for setting up and running the sample

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ You need to have [node](https://nodejs.org/en/) and [npm](https://nodejs.org/en/
 ## Usage
 
 - `git clone https://github.com/Microsoft/vscode-extension-samples`
-- `code <any-sample-folder>`
+- `cd vscode-extension-sample`
+- `cd <any-sample-folder>`
 - `npm install` in the terminal, then `F5` to run the sample
 - Alternatively, follow the instructions in each sample's README for setting up and running the sample
 


### PR DESCRIPTION
Perhaps this is naive, but surely "code" in the original was a "cd" (autocorrect?) typo?