### PR TITLE
Fix test-provider-sample compilation in VSCode 1.62.3

### DIFF
--- a/test-provider-sample/.gitignore
+++ b/test-provider-sample/.gitignore
@@ -4,4 +4,4 @@ node_modules
 *.vsix
 
 /vscode.d.ts
-/vscode.proposed.d.ts
+/vscode.proposed.testCoverage.d.ts

--- a/test-provider-sample/package-lock.json
+++ b/test-provider-sample/package-lock.json
@@ -912,6 +912,12 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
+		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -993,13 +999,13 @@
 			"dev": true
 		},
 		"prompts": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
-			"integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
 			"dev": true,
 			"requires": {
 				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.3"
+				"sisteransi": "^1.0.5"
 			}
 		},
 		"punycode": {
@@ -1039,9 +1045,9 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-			"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
@@ -1081,9 +1087,9 @@
 			"dev": true
 		},
 		"sisteransi": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
-			"integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"dev": true
 		},
 		"slash": {
@@ -1271,22 +1277,14 @@
 			"dev": true
 		},
 		"vscode-dts": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/vscode-dts/-/vscode-dts-0.3.1.tgz",
-			"integrity": "sha512-8XZ+M7IQV5MnPXEhHLemGOk5FRBfT7HCBEughfDhn2i6wwPXlpv4OuQQdhs6XZVmF3GFdKqt+fXOgfsNBKP+fw==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/vscode-dts/-/vscode-dts-0.3.2.tgz",
+			"integrity": "sha512-vL6p3MYuRgyvztEyK/X+7KH8JqMrqzxSvZZi8e0eMubCj2v0POmypitJ93EcHSkZbULA2mCK6mdp5bZ5Re/bZw==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0",
 				"prompts": "^2.1.0",
 				"rimraf": "^3.0.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"which": {

--- a/test-provider-sample/package.json
+++ b/test-provider-sample/package.json
@@ -6,6 +6,9 @@
 	"publisher": "vscode-samples",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples",
 	"enableProposedApi": true,
+	"enabledApiProposals": [
+		"testCoverage"
+	],
 	"engines": {
 		"vscode": "^1.51.0"
 	},
@@ -36,6 +39,6 @@
 		"@typescript-eslint/parser": "^4.16.0",
 		"eslint": "^7.21.0",
 		"typescript": "^4.2.2",
-		"vscode-dts": "^0.3.1"
+		"vscode-dts": "^0.3.2"
 	}
 }


### PR DESCRIPTION
- Update vscode-dts so that it downloads from the correct place
- Add `enabledApiProposals: [ "testCoverage" ]` to package.json.