### PR TITLE
do not encode the `?target=web` query parameter

### DIFF
--- a/lsp-web-extension-sample/client/src/browserClientMain.ts
+++ b/lsp-web-extension-sample/client/src/browserClientMain.ts
@@ -39,7 +39,7 @@ export function activate(context: ExtensionContext) {
 function createWorkerLanguageClient(context: ExtensionContext, clientOptions: LanguageClientOptions) {
 	// Create a worker. The worker main file implements the language server.
 	const serverMain = Uri.joinPath(context.extensionUri, 'server/dist/browserServerMain.js');
-	const worker = new Worker(serverMain.toString());
+	const worker = new Worker(serverMain.toString(true));
 
 	// create the language server client to communicate with the server running in the worker
 	return new LanguageClient('lsp-web-extension-sample', 'LSP Web Extension Sample', clientOptions, worker);


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-extension-samples/issues/560

The path to `browserServerMain.js` has target=web query parameter when running on the web. `Uri.toString()`, by default, encodes the `=` character so the resource is not loaded correctly from the unpkg service when published to marketplace