### PR TITLE
Provide example of executeTask not executing provided task

### DIFF
--- a/task-provider-sample/package.json
+++ b/task-provider-sample/package.json
@@ -17,10 +17,18 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:workbench.action.tasks.runTask"
+		"*"
 	],
 	"main": "./out/extension",
 	"contributes": {
+		"commands": [
+			{
+				"command": "run-custom-task",
+				"title": "Custom task",
+				"category": "Example",
+				"icon": "$(add)"
+			}
+		],
 		"taskDefinitions": [
 			{
 				"type": "rake",

--- a/task-provider-sample/src/extension.ts
+++ b/task-provider-sample/src/extension.ts
@@ -4,20 +4,30 @@
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
 import { RakeTaskProvider } from './rakeTaskProvider';
-import { CustomBuildTaskProvider } from './customTaskProvider';
+import { CustomBuildTaskProvider, command } from './customTaskProvider';
 
 let rakeTaskProvider: vscode.Disposable | undefined;
 let customTaskProvider: vscode.Disposable | undefined;
 
 export function activate(_context: vscode.ExtensionContext): void {
-	const workspaceRoot = (vscode.workspace.workspaceFolders && (vscode.workspace.workspaceFolders.length > 0))
-		? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined;
+	const workspaceRoot =
+		vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0
+			? vscode.workspace.workspaceFolders[0].uri.fsPath
+			: undefined;
 	if (!workspaceRoot) {
 		return;
 	}
-		
-	rakeTaskProvider = vscode.tasks.registerTaskProvider(RakeTaskProvider.RakeType, new RakeTaskProvider(workspaceRoot));
-	customTaskProvider = vscode.tasks.registerTaskProvider(CustomBuildTaskProvider.CustomBuildScriptType, new CustomBuildTaskProvider(workspaceRoot));
+
+	rakeTaskProvider = vscode.tasks.registerTaskProvider(
+		RakeTaskProvider.RakeType,
+		new RakeTaskProvider(workspaceRoot)
+	);
+	customTaskProvider = vscode.tasks.registerTaskProvider(
+		CustomBuildTaskProvider.CustomBuildScriptType,
+		new CustomBuildTaskProvider(workspaceRoot)
+	);
+
+	vscode.commands.registerCommand('run-custom-task', () => command(workspaceRoot));
 }
 
 export function deactivate(): void {


### PR DESCRIPTION
Hi, I have created this to illustrate a behaviour that is confusing me. I hope to link to it from a ticket in the main VS Code repo. I thought that demonstrating it on a sample here might be a good way to illustrate it.

There is a very real chance that I'm making a mistake but I can't see it if I am. Any help would be much appreciated. Either here or in the ticket that I hope to create.

# Issue

I would expect the task output to include the word 'command' as set up
in the line:

```
   () => sharedState + ' command',
```

inside the CustomExecution inside the task created in the command
function.

However it doesn't and instead includes 'getTask' which indicates that
it has run a task provided by the 'provideTasks' method on the provider
rather than the task we have provided directly to the executeTask
function.

# Output

![image](https://user-images.githubusercontent.com/5390/158227800-abeecf04-6cf1-4956-8e11-f830f457553c.png)
