### PR TITLE
Remove unused enableProposedApi

### DIFF
--- a/comment-sample/package.json
+++ b/comment-sample/package.json
@@ -13,7 +13,6 @@
 	"engines": {
 		"vscode": "^1.35.0"
 	},
-	"enableProposedApi": true,
 	"categories": [
 		"Other"
 	],
@@ -161,7 +160,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^12.12.0",
-		"@types/vscode": "^1.35.0",
+		"@types/vscode": "~1.35.0",
 		"@typescript-eslint/eslint-plugin": "^5.19.0",
 		"@typescript-eslint/parser": "^5.19.0",
 		"eslint": "^8.13.0",

--- a/comment-sample/package.json
+++ b/comment-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.35.0"
+		"vscode": "^1.65.0"
 	},
 	"categories": [
 		"Other"
@@ -160,7 +160,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^12.12.0",
-		"@types/vscode": "~1.35.0",
+		"@types/vscode": "~1.65.0",
 		"@typescript-eslint/eslint-plugin": "^5.19.0",
 		"@typescript-eslint/parser": "^5.19.0",
 		"eslint": "^8.13.0",

--- a/extension-terminal-sample/README.md
+++ b/extension-terminal-sample/README.md
@@ -1,17 +1,12 @@
 # extension-terminal-sample
 
-This extension shows how to leverage the extension terminal API proposed in v1.37 that enables an extension to handle a terminal's input and emit output.
+This extension shows how to leverage the extension terminal API stabilized in v1.39 that enables an extension to handle a terminal's input and emit output.
 
 ## VS Code API
 
 ### `vscode` module
 
 - [window.createTerminal](https://code.visualstudio.com/api/references/vscode-api#window.createTerminal)
-
-### Proposed API
-
-- `window.Pseudoterminal`
-- `window.ExtensionTerminalOptions`
 
 ### Contribution Points
 

--- a/extension-terminal-sample/package.json
+++ b/extension-terminal-sample/package.json
@@ -11,9 +11,8 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.37.0"
+		"vscode": "^1.39.0"
 	},
-	"enableProposedApi": true,
 	"categories": [
 		"Other"
 	],
@@ -42,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^12.12.0",
-		"@types/vscode": "^1.33.0",
+		"@types/vscode": "~1.39.0",
 		"@typescript-eslint/eslint-plugin": "^5.19.0",
 		"@typescript-eslint/parser": "^5.19.0",
 		"eslint": "^8.13.0",

--- a/extension-terminal-sample/src/extension.ts
+++ b/extension-terminal-sample/src/extension.ts
@@ -31,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
 				writeEmitter.fire(data);
 			}
 		};
-		const terminal = (<any>vscode.window).createTerminal({ name: `My Extension REPL`, pty });
+		const terminal = vscode.window.createTerminal({ name: `My Extension REPL`, pty });
 		terminal.show();
 	}));
 


### PR DESCRIPTION
Removed `enableProposedApi` from [comment-sample](https://github.com/microsoft/vscode-extension-samples/tree/main/comment-sample) and [extension-terminal-sample](https://github.com/microsoft/vscode-extension-samples/tree/main/extension-terminal-sample) as it is unnecessary and deprecated.

Mentioned in #555