### PR TITLE
fix: inlineCompletions renamed to inlineCompletionsAdditions

### DIFF
--- a/inline-completions/package.json
+++ b/inline-completions/package.json
@@ -1,6 +1,6 @@
 {
 	"enabledApiProposals": [
-		"inlineCompletions"
+		"inlineCompletionsAdditions"
 	],
 	"name": "inline-completion-sample",
 	"displayName": "Inline Completion Sample",


### PR DESCRIPTION
I just cloned the inline-completion folder and VSCode showed me a warning in package.json:
![image](https://user-images.githubusercontent.com/10288728/178959535-ef32e945-9376-4906-8e0a-71eab3e17441.png)

After investigation, it seams that `inlineCompletions` has been renamed to `inlineCompletionsAdditions` in VSCode API.