### PR TITLE
lsp-embedded-request-forwarding: don't encode uri used in map (fix #682)

### DIFF
--- a/lsp-embedded-request-forwarding/client/src/extension.ts
+++ b/lsp-embedded-request-forwarding/client/src/extension.ts
@@ -50,7 +50,7 @@ export function activate(context: ExtensionContext) {
 					return await next(document, position, context, token);
 				}
 
-				const originalUri = document.uri.toString();
+				const originalUri = document.uri.toString(true);
 				virtualDocumentContents.set(originalUri, getCSSVirtualContent(htmlLanguageService, document.getText()));
 
 				const vdocUriString = `embedded-content://css/${encodeURIComponent(


### PR DESCRIPTION
This PR fixes #682