### PR TITLE
chore: replace `--inspect` with `--inspect-brk`

### DIFF
--- a/lsp-sample/client/src/extension.ts
+++ b/lsp-sample/client/src/extension.ts
@@ -21,8 +21,8 @@ export function activate(context: ExtensionContext) {
 		path.join('server', 'out', 'server.js')
 	);
 	// The debug options for the server
-	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-	const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+	// --inspect-brk=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging and break at start.
+	const debugOptions = { execArgv: ['--nolazy', '--inspect-brk=6009'] };
 
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used


### PR DESCRIPTION
It's for debugging breakpoints in `onInitialize` and `onInitialized` which bothered me a lot.