### PR TITLE
eamodio.tsl-problem-matcher changed id

### DIFF
--- a/helloworld-web-sample/.vscode/extensions.json
+++ b/helloworld-web-sample/.vscode/extensions.json
@@ -3,6 +3,6 @@
 	// for the documentation about the extensions.json format
 	"recommendations": [
 		"dbaeumer.vscode-eslint",
-		"eamodio.tsl-problem-matcher"
+		"amodio.tsl-problem-matcher"
 	]
 }

--- a/notebook-extend-markdown-renderer-sample/.vscode/extensions.json
+++ b/notebook-extend-markdown-renderer-sample/.vscode/extensions.json
@@ -3,6 +3,6 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "eamodio.tsl-problem-matcher"
+    "amodio.tsl-problem-matcher"
   ]
 }

--- a/notebook-renderer-react-sample/.vscode/extensions.json
+++ b/notebook-renderer-react-sample/.vscode/extensions.json
@@ -3,6 +3,6 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "eamodio.tsl-problem-matcher"
+    "amodio.tsl-problem-matcher"
   ]
 }

--- a/notebook-renderer-sample/.vscode/extensions.json
+++ b/notebook-renderer-sample/.vscode/extensions.json
@@ -3,6 +3,6 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "eamodio.tsl-problem-matcher"
+    "amodio.tsl-problem-matcher"
   ]
 }


### PR DESCRIPTION
This is a PR to solve issue #714 
After the changes vscode no longer complains about `"... eamodio.tsl-problem-matcher (not found in marketplace)"` when adding certain folders, ( `notebook-*` and `helloworld-web-sample`) to a workspace.
As mentioned in #714 the owner has changed id of his extension on Marketplace to `amodio.tsl-problem-matcher`.
Please read issue #714 for further info and references.