### PR TITLE
use auto attach children instead of multiple launch configs

### DIFF
--- a/lsp-embedded-language-service/.vscode/launch.json
+++ b/lsp-embedded-language-service/.vscode/launch.json
@@ -9,18 +9,11 @@
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
+			"autoAttachChildProcesses": true,
 			"preLaunchTask": {
 				"type": "npm",
 				"script": "watch"
 			}
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Server",
-			"port": 6009,
-			"restart": true,
-			"outFiles": ["${workspaceRoot}/server/out/**/*.js"]
 		},
 		{
 			"name": "Language Server E2E Test",
@@ -33,12 +26,6 @@
 				"${workspaceRoot}/client/testFixture"
 			],
 			"outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
-		}
-	],
-	"compounds": [
-		{
-			"name": "Client + Server",
-			"configurations": ["Launch Client", "Attach to Server"]
 		}
 	]
 }

--- a/lsp-embedded-language-service/client/src/extension.ts
+++ b/lsp-embedded-language-service/client/src/extension.ts
@@ -20,10 +20,6 @@ export function activate(context: ExtensionContext) {
 	const serverModule = context.asAbsolutePath(
 		path.join('server', 'out', 'server.js')
 	);
-	// The debug options for the server
-	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-	const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
-
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
 	const serverOptions: ServerOptions = {
@@ -31,7 +27,6 @@ export function activate(context: ExtensionContext) {
 		debug: {
 			module: serverModule,
 			transport: TransportKind.ipc,
-			options: debugOptions
 		}
 	};
 

--- a/lsp-embedded-request-forwarding/.vscode/launch.json
+++ b/lsp-embedded-request-forwarding/.vscode/launch.json
@@ -9,18 +9,11 @@
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
+			"autoAttachChildProcesses": true,
 			"preLaunchTask": {
 				"type": "npm",
 				"script": "watch"
 			}
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Server",
-			"port": 6009,
-			"restart": true,
-			"outFiles": ["${workspaceRoot}/server/out/**/*.js"]
 		},
 		{
 			"name": "Language Server E2E Test",
@@ -33,12 +26,6 @@
 				"${workspaceRoot}/client/testFixture"
 			],
 			"outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
-		}
-	],
-	"compounds": [
-		{
-			"name": "Client + Server",
-			"configurations": ["Launch Client", "Attach to Server"]
 		}
 	]
 }

--- a/lsp-embedded-request-forwarding/client/src/extension.ts
+++ b/lsp-embedded-request-forwarding/client/src/extension.ts
@@ -16,9 +16,6 @@ const htmlLanguageService = getLanguageService();
 export function activate(context: ExtensionContext) {
 	// The server is implemented in node
 	const serverModule = context.asAbsolutePath(path.join('server', 'out', 'server.js'));
-	// The debug options for the server
-	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-	const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
 
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
@@ -27,7 +24,6 @@ export function activate(context: ExtensionContext) {
 		debug: {
 			module: serverModule,
 			transport: TransportKind.ipc,
-			options: debugOptions
 		}
 	};
 

--- a/lsp-log-streaming-sample/.vscode/launch.json
+++ b/lsp-log-streaming-sample/.vscode/launch.json
@@ -8,20 +8,10 @@
 			"name": "Launch Client",
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-			"stopOnEntry": false,
+			"autoAttachChildProcesses": true,
 			"sourceMaps": true,
 			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
 			"preLaunchTask": "npm: watch:client"
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Server",
-			"address": "localhost",
-			"protocol": "inspector",
-			"port": 6009,
-			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/server/out/**/*.js"]
 		},
 		{
 			"name": "Language Server E2E Test",
@@ -33,15 +23,8 @@
 				"--extensionTestsPath=${workspaceRoot}/client/out/test",
 				"${workspaceRoot}/client/testFixture"
 			],
-			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
-		}
-	],
-	"compounds": [
-		{
-			"name": "Client + Server",
-			"configurations": ["Launch Client", "Attach to Server"]
 		}
 	]
 }

--- a/lsp-log-streaming-sample/client/src/extension.ts
+++ b/lsp-log-streaming-sample/client/src/extension.ts
@@ -29,9 +29,6 @@ export function activate(context: ExtensionContext) {
 	const serverModule = context.asAbsolutePath(
 		path.join('server', 'out', 'server.js')
 	);
-	// The debug options for the server
-	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-	const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
 
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
@@ -40,7 +37,6 @@ export function activate(context: ExtensionContext) {
 		debug: {
 			module: serverModule,
 			transport: TransportKind.ipc,
-			options: debugOptions
 		}
 	};
 

--- a/lsp-multi-server-sample/.vscode/launch.json
+++ b/lsp-multi-server-sample/.vscode/launch.json
@@ -8,30 +8,10 @@
 			"name": "Launch Client",
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-			"stopOnEntry": false,
+			"autoAttachChildProcesses": true,
 			"sourceMaps": true,
 			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
 			"preLaunchTask": "npm: watch"
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Server 6011",
-			"address": "localhost",
-			"protocol": "inspector",
-			"port": 6011,
-			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/server/out/**/*.js"]
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Server 6012",
-			"address": "localhost",
-			"protocol": "inspector",
-			"port": 6012,
-			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/server/out/**/*.js"]
 		}
 	]
 }

--- a/lsp-multi-server-sample/client/src/extension.ts
+++ b/lsp-multi-server-sample/client/src/extension.ts
@@ -61,10 +61,9 @@ export function activate(context: ExtensionContext) {
 		const uri = document.uri;
 		// Untitled files go to a default client.
 		if (uri.scheme === 'untitled' && !defaultClient) {
-			const debugOptions = { execArgv: ["--nolazy", "--inspect=6010"] };
 			const serverOptions = {
 				run: { module, transport: TransportKind.ipc },
-				debug: { module, transport: TransportKind.ipc, options: debugOptions}
+				debug: { module, transport: TransportKind.ipc }
 			};
 			const clientOptions: LanguageClientOptions = {
 				documentSelector: [
@@ -87,10 +86,9 @@ export function activate(context: ExtensionContext) {
 		folder = getOuterMostWorkspaceFolder(folder);
 
 		if (!clients.has(folder.uri.toString())) {
-			const debugOptions = { execArgv: ["--nolazy", `--inspect=${6011 + clients.size}`] };
 			const serverOptions = {
 				run: { module, transport: TransportKind.ipc },
-				debug: { module, transport: TransportKind.ipc, options: debugOptions}
+				debug: { module, transport: TransportKind.ipc }
 			};
 			const clientOptions: LanguageClientOptions = {
 				documentSelector: [

--- a/lsp-sample/.vscode/launch.json
+++ b/lsp-sample/.vscode/launch.json
@@ -9,18 +9,11 @@
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
+			"autoAttachChildProcesses": true,
 			"preLaunchTask": {
 				"type": "npm",
 				"script": "watch"
 			}
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Server",
-			"port": 6009,
-			"restart": true,
-			"outFiles": ["${workspaceRoot}/server/out/**/*.js"]
 		},
 		{
 			"name": "Language Server E2E Test",
@@ -33,12 +26,6 @@
 				"${workspaceRoot}/client/testFixture"
 			],
 			"outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
-		}
-	],
-	"compounds": [
-		{
-			"name": "Client + Server",
-			"configurations": ["Launch Client", "Attach to Server"]
 		}
 	]
 }

--- a/lsp-sample/README.md
+++ b/lsp-sample/README.md
@@ -32,7 +32,6 @@ It also includes an End-to-End test.
 - Switch to the Run and Debug View in the Sidebar (Ctrl+Shift+D).
 - Select `Launch Client` from the drop down (if it is not already).
 - Press ▷ to run the launch config (F5).
-- If you want to debug the server as well, use the launch configuration `Attach to Server`
 - In the [Extension Development Host](https://code.visualstudio.com/api/get-started/your-first-extension#:~:text=Then%2C%20inside%20the%20editor%2C%20press%20F5.%20This%20will%20compile%20and%20run%20the%20extension%20in%20a%20new%20Extension%20Development%20Host%20window.) instance of VSCode, open a document in 'plain text' language mode.
   - Type `j` or `t` to see `Javascript` and `TypeScript` completion.
   - Enter text content such as `AAA aaa BBB`. The extension will emit diagnostics for all words in all-uppercase.

--- a/lsp-sample/client/src/extension.ts
+++ b/lsp-sample/client/src/extension.ts
@@ -20,9 +20,6 @@ export function activate(context: ExtensionContext) {
 	const serverModule = context.asAbsolutePath(
 		path.join('server', 'out', 'server.js')
 	);
-	// The debug options for the server
-	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-	const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
 
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
@@ -31,7 +28,6 @@ export function activate(context: ExtensionContext) {
 		debug: {
 			module: serverModule,
 			transport: TransportKind.ipc,
-			options: debugOptions
 		}
 	};
 

--- a/lsp-user-input-sample/.vscode/launch.json
+++ b/lsp-user-input-sample/.vscode/launch.json
@@ -8,26 +8,10 @@
 			"name": "Launch Client",
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceFolder}" ],
-			"stopOnEntry": false,
+			"autoAttachChildProcesses": true,
 			"sourceMaps": true,
 			"outFiles": ["${workspaceFolder}/client/out/**/*.js"],
 			"preLaunchTask": "npm: watch"
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Server",
-			"address": "localhost",
-			"protocol": "inspector",
-			"port": 6011,
-			"sourceMaps": true,
-			"outFiles": ["${workspaceFolder}/server/out/**/*.js"]
-		}
-	],
-	"compounds": [
-		{
-			"name": "Client + Server",
-			"configurations": ["Launch Client", "Attach to Server"]
 		}
 	]
 }

--- a/lsp-user-input-sample/client/src/extension.ts
+++ b/lsp-user-input-sample/client/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: ExtensionContext): void {
 	const serverModule = context.asAbsolutePath(path.join('server', 'out', 'sampleServer.js'));
 	let serverOptions: ServerOptions = {
 		run: { module: serverModule, transport: TransportKind.ipc, options: { cwd: process.cwd() } },
-		debug: { module: serverModule, transport: TransportKind.ipc, options: { execArgv: ['--nolazy', '--inspect=6011'], cwd: process.cwd() } }
+		debug: { module: serverModule, transport: TransportKind.ipc, options: { cwd: process.cwd() } }
 	};
 
 	let clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
This is a new (with js-debug) option that makes debugging child processes much easier. Use it for the LSP subprocesses.

Supplants https://github.com/microsoft/vscode-extension-samples/pull/704