### PR TITLE
lsp-sample: add language contribution to manifest

### DIFF
--- a/lsp-sample/package.json
+++ b/lsp-sample/package.json
@@ -41,7 +41,16 @@
 					"description": "Traces the communication between VS Code and the language server."
 				}
 			}
-		}
+		},
+		"languages": [
+			{
+				"id": "plaintext",
+				"extensions": [
+					".txt"
+				],
+				"aliases": ["Plain Text"]
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",


### PR DESCRIPTION
Looks like this was missed when the sample extension and the guide were updated to reflect the changes to VSCode 1.74.0 and higher.

This allows for the implicit activation documented in the [release notes](https://code.visualstudio.com/updates/v1_74#_extension-authoring) and the respective docs.