### PR TITLE
update @types/vscode to latest available

### DIFF
--- a/statusbar-sample/package-lock.json
+++ b/statusbar-sample/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"devDependencies": {
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.74.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
@@ -123,9 +123,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1688,9 +1688,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/statusbar-sample/package.json
+++ b/statusbar-sample/package.json
@@ -30,7 +30,7 @@
 		"watch": "tsc -watch -p ./"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.74.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",


### PR DESCRIPTION
Hi there,

I was playing around with making my own custom statusbar extension. I wanted to set the `backgroundColor` and I was confused why it wouldn't compile. Turned out it was using an older version of the type definitions. Updating fixed the issue.

I wonder if you'd consider trying to automate the samples so that they were updated whenever a new version was released?

Thanks!