### PR TITLE
Bump old `vscode` versions in samples

### DIFF
--- a/.base-sample/package.json
+++ b/.base-sample/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.74.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/basic-multi-root-sample/package-lock.json
+++ b/basic-multi-root-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/basic-multi-root-sample/package.json
+++ b/basic-multi-root-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -44,7 +44,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/call-hierarchy-sample/package-lock.json
+++ b/call-hierarchy-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.40.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.40.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-			"integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-			"integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/call-hierarchy-sample/package.json
+++ b/call-hierarchy-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.40.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -28,7 +28,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.40.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/code-actions-sample/package-lock.json
+++ b/code-actions-sample/package-lock.json
@@ -9,14 +9,14 @@
 			"version": "0.0.2",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -129,9 +129,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1700,9 +1700,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/code-actions-sample/package.json
+++ b/code-actions-sample/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples/issues"
 	},
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -29,7 +29,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/codelens-sample/package-lock.json
+++ b/codelens-sample/package-lock.json
@@ -10,14 +10,14 @@
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^16.11.7",
-                "@types/vscode": "^1.26.0",
+                "@types/vscode": "^1.73.0",
                 "@typescript-eslint/eslint-plugin": "^5.42.0",
                 "@typescript-eslint/parser": "^5.42.0",
                 "eslint": "^8.26.0",
                 "typescript": "^4.9.4"
             },
             "engines": {
-                "vscode": "^1.26.0"
+                "vscode": "^1.73.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.41.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.41.0.tgz",
-            "integrity": "sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==",
+            "version": "1.74.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.41.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.41.0.tgz",
-            "integrity": "sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==",
+            "version": "1.74.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/codelens-sample/package.json
+++ b/codelens-sample/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/Microsoft/vscode-extension-samples"
     },
     "engines": {
-        "vscode": "^1.26.0"
+        "vscode": "^1.73.0"
     },
     "categories": [
         "Other"
@@ -50,7 +50,7 @@
     },
     "devDependencies": {
         "@types/node": "^16.11.7",
-        "@types/vscode": "^1.26.0",
+        "@types/vscode": "^1.73.0",
         "@typescript-eslint/eslint-plugin": "^5.42.0",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint": "^8.26.0",

--- a/comment-sample/package-lock.json
+++ b/comment-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "~1.65.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.65.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.65.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-			"integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.65.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-			"integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/comment-sample/package.json
+++ b/comment-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.65.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -160,7 +160,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "~1.65.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/completions-sample/package-lock.json
+++ b/completions-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/completions-sample/package.json
+++ b/completions-sample/package.json
@@ -10,7 +10,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -27,7 +27,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/decorator-sample/package-lock.json
+++ b/decorator-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/decorator-sample/package.json
+++ b/decorator-sample/package.json
@@ -5,7 +5,7 @@
 	"publisher": "vscode-samples",
 	"license": "MIT",
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"repository": {
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/diagnostic-related-information-sample/package-lock.json
+++ b/diagnostic-related-information-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/diagnostic-related-information-sample/package.json
+++ b/diagnostic-related-information-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -28,7 +28,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/extension-terminal-sample/package-lock.json
+++ b/extension-terminal-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "~1.73",
+				"@types/vscode": "^1.74.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.74.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.73.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
-			"integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.73.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
-			"integrity": "sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/extension-terminal-sample/package.json
+++ b/extension-terminal-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.74.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "~1.73",
+		"@types/vscode": "^1.74.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/getting-started-sample/package-lock.json
+++ b/getting-started-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.57.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.56.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-			"integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.56.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-			"integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/getting-started-sample/package.json
+++ b/getting-started-sample/package.json
@@ -8,7 +8,7 @@
 	"license": "MIT",
 	"repository": "https://github.com/Microsoft/vscode-extension-samples/getting-started-sample",
 	"engines": {
-		"vscode": "^1.57.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -206,7 +206,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/progress-sample/package-lock.json
+++ b/progress-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/progress-sample/package.json
+++ b/progress-sample/package.json
@@ -14,7 +14,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples/issues"
 	},
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/proposed-api-sample/vscode.d.ts
+++ b/proposed-api-sample/vscode.d.ts
@@ -206,7 +206,7 @@ declare module 'vscode' {
 		/**
 		 * Get a word-range at the given position. By default words are defined by
 		 * common separators, like space, -, _, etc. In addition, per language custom
-		 * [word definitions} can be defined. It
+		 * [word definitions] can be defined. It
 		 * is also possible to provide a custom regular expression.
 		 *
 		 * * *Note 1:* A custom regular expression must not match the empty string and
@@ -3647,22 +3647,6 @@ declare module 'vscode' {
 		has(uri: Uri): boolean;
 
 		/**
-		 * Set (and replace) notebook edits for a resource.
-		 *
-		 * @param uri A resource identifier.
-		 * @param edits An array of edits.
-		 */
-		set(uri: Uri, edits: readonly NotebookEdit[]): void;
-
-		/**
-		 * Set (and replace) notebook edits with metadata for a resource.
-		 *
-		 * @param uri A resource identifier.
-		 * @param edits An array of edits.
-		 */
-		set(uri: Uri, edits: ReadonlyArray<[NotebookEdit, WorkspaceEditEntryMetadata]>): void;
-
-		/**
 		 * Set (and replace) text edits or snippet edits for a resource.
 		 *
 		 * @param uri A resource identifier.
@@ -3677,6 +3661,22 @@ declare module 'vscode' {
 		 * @param edits An array of edits.
 		 */
 		set(uri: Uri, edits: ReadonlyArray<[TextEdit | SnippetTextEdit, WorkspaceEditEntryMetadata]>): void;
+
+		/**
+		 * Set (and replace) notebook edits for a resource.
+		 *
+		 * @param uri A resource identifier.
+		 * @param edits An array of edits.
+		 */
+		set(uri: Uri, edits: readonly NotebookEdit[]): void;
+
+		/**
+		 * Set (and replace) notebook edits with metadata for a resource.
+		 *
+		 * @param uri A resource identifier.
+		 * @param edits An array of edits.
+		 */
+		set(uri: Uri, edits: ReadonlyArray<[NotebookEdit, WorkspaceEditEntryMetadata]>): void;
 
 		/**
 		 * Get the text edits for a resource.
@@ -9030,7 +9030,7 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * Additional information used to implement {@linkcode CustomEditableDocument.backup}.
+	 * Additional information used to implement {@linkcode CustomDocumentBackup}.
 	 */
 	interface CustomDocumentBackupContext {
 		/**
@@ -9362,6 +9362,15 @@ declare module 'vscode' {
 		 * `true` if the user has enabled telemetry or `false` if the user has disabled telemetry.
 		 */
 		export const onDidChangeTelemetryEnabled: Event<boolean>;
+
+		/**
+		 * Creates a new {@link TelemetryLogger telemetry logger}.
+		 *
+		 * @param sender The telemetry sender that is used by the telemetry logger.
+		 * @param options Options for the telemetry logger.
+		 * @returns A new telemetry logger
+		 */
+		export function createTelemetryLogger(sender: TelemetrySender, options?: TelemetryLoggerOptions): TelemetryLogger;
 
 		/**
 		 * The name of a remote. Defined by extensions, popular samples are `wsl` for the Windows
@@ -12435,11 +12444,11 @@ declare module 'vscode' {
 		export const notebookDocuments: readonly NotebookDocument[];
 
 		/**
-		 * Open a notebook. Will return early if this notebook is already {@link notebook.notebookDocuments loaded}. Otherwise
-		 * the notebook is loaded and the {@linkcode notebook.onDidOpenNotebookDocument onDidOpenNotebookDocument}-event fires.
+		 * Open a notebook. Will return early if this notebook is already {@link notebookDocuments loaded}. Otherwise
+		 * the notebook is loaded and the {@linkcode onDidOpenNotebookDocument}-event fires.
 		 *
 		 * *Note* that the lifecycle of the returned notebook is owned by the editor and not by the extension. That means an
-		 * {@linkcode notebook.onDidCloseNotebookDocument onDidCloseNotebookDocument}-event can occur at any time after.
+		 * {@linkcode onDidCloseNotebookDocument}-event can occur at any time after.
 		 *
 		 * *Note* that opening a notebook does not show a notebook editor. This function only returns a notebook document which
 		 * can be shown in a notebook editor but it can also be used for other things.
@@ -15068,7 +15077,7 @@ declare module 'vscode' {
 		 *
 		 * @param debugType The debug type for which the provider is registered.
 		 * @param provider The {@link DebugConfigurationProvider debug configuration provider} to register.
-		 * @param triggerKind The {@link DebugConfigurationProviderTrigger trigger} for which the 'provideDebugConfiguration' method of the provider is registered. If `triggerKind` is missing, the value `DebugConfigurationProviderTriggerKind.Initial` is assumed.
+		 * @param triggerKind The {@link DebugConfigurationProviderTriggerKind trigger} for which the 'provideDebugConfiguration' method of the provider is registered. If `triggerKind` is missing, the value `DebugConfigurationProviderTriggerKind.Initial` is assumed.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
 		 */
 		export function registerDebugConfigurationProvider(debugType: string, provider: DebugConfigurationProvider, triggerKind?: DebugConfigurationProviderTriggerKind): Disposable;
@@ -15223,6 +15232,14 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * The state of a comment thread.
+	 */
+	export enum CommentThreadState {
+		Unresolved = 0,
+		Resolved = 1
+	}
+
+	/**
 	 * A collection of {@link Comment comments} representing a conversation at a particular range in a document.
 	 */
 	export interface CommentThread {
@@ -15278,6 +15295,11 @@ declare module 'vscode' {
 		 * The optional human-readable label describing the {@link CommentThread Comment Thread}
 		 */
 		label?: string;
+
+		/**
+		 * The optional state of a comment thread, which may affect how the comment is displayed.
+		 */
+		state?: CommentThreadState;
 
 		/**
 		 * Dispose this comment thread.
@@ -15803,8 +15825,8 @@ declare module 'vscode' {
 		 */
 		export function t(options: {
 			/**
-			 * The message to localize. If {@link args} is an array, this message supports index templating where strings like
-			 * `{0}` and `{1}` are replaced by the item at that index in the {@link args} array. If `args` is a `Record<string, any>`,
+			 * The message to localize. If {@link options.args args} is an array, this message supports index templating where strings like
+			 * `{0}` and `{1}` are replaced by the item at that index in the {@link options.args args} array. If `args` is a `Record<string, any>`,
 			 * this supports named templating where strings like `{foo}` and `{bar}` are replaced by the value in
 			 * the Record for that key (foo, bar, etc).
 			 */
@@ -15951,7 +15973,7 @@ declare module 'vscode' {
 	 */
 	export interface TestController {
 		/**
-		 * The id of the controller passed in {@link vscode.tests.createTestController}.
+		 * The id of the controller passed in {@link tests.createTestController}.
 		 * This must be globally unique.
 		 */
 		readonly id: string;
@@ -15967,7 +15989,7 @@ declare module 'vscode' {
 		 * "test tree."
 		 *
 		 * The extension controls when to add tests. For example, extensions should
-		 * add tests for a file when {@link vscode.workspace.onDidOpenTextDocument}
+		 * add tests for a file when {@link workspace.onDidOpenTextDocument}
 		 * fires in order for decorations for tests within a file to be visible.
 		 *
 		 * However, the editor may sometimes explicitly request children using the
@@ -15992,7 +16014,7 @@ declare module 'vscode' {
 		 * A function provided by the extension that the editor may call to request
 		 * children of a test item, if the {@link TestItem.canResolveChildren} is
 		 * `true`. When called, the item should discover children and call
-		 * {@link vscode.tests.createTestItem} as children are discovered.
+		 * {@link TestController.createTestItem} as children are discovered.
 		 *
 		 * Generally the extension manages the lifecycle of test items, but under
 		 * certain conditions the editor may request the children of a specific
@@ -16276,7 +16298,7 @@ declare module 'vscode' {
 
 		/**
 		 * Tags associated with this test item. May be used in combination with
-		 * {@link TestRunProfile.tags}, or simply as an organizational feature.
+		 * {@link TestRunProfile.tag tags}, or simply as an organizational feature.
 		 */
 		tags: readonly TestTag[];
 
@@ -16589,7 +16611,7 @@ declare module 'vscode' {
 		 * Whether or not the group is currently active.
 		 *
 		 * *Note* that only one tab group is active at a time, but that multiple tab
-		 * groups can have an {@link TabGroup.aciveTab active tab}.
+		 * groups can have an {@link activeTab active tab}.
 		 *
 		 * @see {@link Tab.isActive}
 		 */
@@ -16658,6 +16680,144 @@ declare module 'vscode' {
 		 * @returns A promise that resolves to `true` when all tab groups have been closed.
 		 */
 		close(tabGroup: TabGroup | readonly TabGroup[], preserveFocus?: boolean): Thenable<boolean>;
+	}
+
+	/**
+	 * A special value wrapper denoting a value that is safe to not clean.
+	 * This is to be used when you can guarantee no identifiable information is contained in the value and the cleaning is improperly redacting it.
+	 */
+	export class TelemetryTrustedValue<T = any> {
+		readonly value: T;
+
+		constructor(value: T);
+	}
+
+	/**
+	 * A telemetry logger which can be used by extensions to log usage and error telementry.
+	 *
+	 * A logger wraps around an {@link TelemetrySender sender} but it guarantees that
+	 * - user settings to disable or tweak telemetry are respected, and that
+	 * - potential sensitive data is removed
+	 *
+	 * It also enables an "echo UI" that prints whatever data is send and it allows the editor
+	 * to forward unhandled errors to the respective extensions.
+	 *
+	 * To get an instance of a `TelemetryLogger`, use
+	 * {@link env.createTelemetryLogger `createTelemetryLogger`}.
+	 */
+	export interface TelemetryLogger {
+
+		/**
+		 * An {@link Event} which fires when the enablement state of usage or error telemetry changes.
+		 */
+		readonly onDidChangeEnableStates: Event<TelemetryLogger>;
+
+		/**
+		 * Whether or not usage telemetry is enabled for this logger.
+		 */
+		readonly isUsageEnabled: boolean;
+
+		/**
+		 * Whether or not error telemetry is enabled for this logger.
+		 */
+		readonly isErrorsEnabled: boolean;
+
+		/**
+		 * Log a usage event.
+		 *
+		 * After completing cleaning, telemetry setting checks, and data mix-in calls `TelemetrySender.sendEventData` to log the event.
+		 * Automatically supports echoing to extension telemetry output channel.
+		 * @param eventName The event name to log
+		 * @param data The data to log
+		 */
+		logUsage(eventName: string, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+		/**
+		 * Log an error event.
+		 *
+		 * After completing cleaning, telemetry setting checks, and data mix-in calls `TelemetrySender.sendEventData` to log the event. Differs from `logUsage` in that it will log the event if the telemetry setting is Error+.
+		 * Automatically supports echoing to extension telemetry output channel.
+		 * @param eventName The event name to log
+		 * @param data The data to log
+		 */
+		logError(eventName: string, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+		/**
+		 * Log an error event.
+		 *
+		 * Calls `TelemetrySender.sendErrorData`. Does cleaning, telemetry checks, and data mix-in.
+		 * Automatically supports echoing to extension telemetry output channel.
+		 * Will also automatically log any exceptions thrown within the extension host process.
+		 * @param error The error object which contains the stack trace cleaned of PII
+		 * @param data Additional data to log alongside the stack trace
+		 */
+		logError(error: Error, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+		/**
+		 * Dispose this object and free resources.
+		 */
+		dispose(): void;
+	}
+
+	/**
+	 * The telemetry sender is the contract between a telemetry logger and some telemetry service. **Note** that extensions must NOT
+	 * call the methods of their sender directly as the logger provides extra guards and cleaning.
+	 *
+	 * ```js
+	 * const sender: vscode.TelemetrySender = {...};
+	 * const logger = vscode.env.createTelemetryLogger(sender);
+	 *
+	 * // GOOD - uses the logger
+	 * logger.logUsage('myEvent', { myData: 'myValue' });
+	 *
+	 * // BAD - uses the sender directly: no data cleansing, ignores user settings, no echoing to the telemetry output channel etc
+	 * sender.logEvent('myEvent', { myData: 'myValue' });
+	 * ```
+	 */
+	export interface TelemetrySender {
+		/**
+		 * Function to send event data without a stacktrace. Used within a {@link TelemetryLogger}
+		 *
+		 * @param eventName The name of the event which you are logging
+		 * @param data A serializable key value pair that is being logged
+		 */
+		sendEventData(eventName: string, data?: Record<string, any>): void;
+
+		/**
+		 * Function to send an error. Used within a {@link TelemetryLogger}
+		 *
+		 * @param error The error being logged
+		 * @param data Any additional data to be collected with the exception
+		 */
+		sendErrorData(error: Error, data?: Record<string, any>): void;
+
+		/**
+		 * Optional flush function which will give this sender a chance to send any remaining events
+		 * as its {@link TelemetryLogger} is being disposed
+		 */
+		flush?(): void | Thenable<void>;
+	}
+
+	/**
+	 * Options for creating a {@link TelemetryLogger}
+	 */
+	export interface TelemetryLoggerOptions {
+		/**
+		 * Whether or not you want to avoid having the built-in common properties such as os, extension name, etc injected into the data object.
+		 * Defaults to `false` if not defined.
+		 */
+		readonly ignoreBuiltInCommonProperties?: boolean;
+
+		/**
+		 * Whether or not unhandled errors on the extension host caused by your extension should be logged to your sender.
+		 * Defaults to `false` if not defined.
+		 */
+		readonly ignoreUnhandledErrors?: boolean;
+
+		/**
+		 * Any additional common properties which should be injected into the data object.
+		 */
+		readonly additionalCommonProperties?: Record<string, any>;
 	}
 }
 

--- a/quickinput-sample/package-lock.json
+++ b/quickinput-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/quickinput-sample/package.json
+++ b/quickinput-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/statusbar-sample/package-lock.json
+++ b/statusbar-sample/package-lock.json
@@ -9,14 +9,14 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"devDependencies": {
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -123,9 +123,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1688,9 +1688,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/statusbar-sample/package.json
+++ b/statusbar-sample/package.json
@@ -14,7 +14,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples/issues"
 	},
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -30,7 +30,7 @@
 		"watch": "tsc -watch -p ./"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/task-provider-sample/package-lock.json
+++ b/task-provider-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.45.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.45.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.45.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.1.tgz",
-			"integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.45.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.1.tgz",
-			"integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/task-provider-sample/package.json
+++ b/task-provider-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.45.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -63,7 +63,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.45.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",

--- a/vim-sample/package-lock.json
+++ b/vim-sample/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.7",
-				"@types/vscode": "^1.32.0",
+				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.42.0",
 				"@typescript-eslint/parser": "^5.42.0",
 				"eslint": "^8.26.0",
 				"typescript": "^4.9.4"
 			},
 			"engines": {
-				"vscode": "^1.32.0"
+				"vscode": "^1.73.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -130,9 +130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -1701,9 +1701,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-			"integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/vim-sample/package.json
+++ b/vim-sample/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-extension-samples"
 	},
 	"engines": {
-		"vscode": "^1.32.0"
+		"vscode": "^1.73.0"
 	},
 	"categories": [
 		"Other"
@@ -78,7 +78,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7",
-		"@types/vscode": "^1.32.0",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.42.0",
 		"@typescript-eslint/parser": "^5.42.0",
 		"eslint": "^8.26.0",


### PR DESCRIPTION
This bumps the `@types/vscode` and `engines: vscode` on packages that were using very old versions. These old versions used a `vscode.d.ts` that didn't include proper link support. We've also made a number of fixes and improvements to `vscode.d.ts` that are useful to extension authors