### PR TITLE
Fix debugging of tree view sample

### DIFF
--- a/tree-view-sample/.vscode/launch.json
+++ b/tree-view-sample/.vscode/launch.json
@@ -12,10 +12,9 @@
                 "--enable-proposed-api",
                 "vscode-samples.custom-view-samples"
             ],
-            "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [
-                "${workspaceRoot}/out/src/**/*.js"
+                "${workspaceRoot}/out/**/*.js"
             ],
             "preLaunchTask": "npm: watch"
         },
@@ -23,11 +22,10 @@
             "type": "node",
             "request": "attach",
             "name": "Attach to Extension Host",
-            "protocol": "inspector",
             "port": 5870,
             "restart": true,
             "outFiles": [
-                "${workspaceRoot}/out/src"
+                "${workspaceRoot}/out"
             ]
         }
     ]


### PR DESCRIPTION
The files are directly under `out`, not under `out/src`