### PR TITLE
Fix exception when trying to use negative line numbers

### DIFF
--- a/inline-completions/src/extension.ts
+++ b/inline-completions/src/extension.ts
@@ -22,9 +22,13 @@ export function activate(context: vscode.ExtensionContext) {
 
 			let offset = 1;
 			while (offset > 0) {
+				if (position.line - offset < 0) {
+					break;
+				}
+				
 				const lineBefore = document.lineAt(position.line - offset).text;
 				const matches = lineBefore.match(regexp);
-				if (!matches || position.line - offset < 0) {
+				if (!matches) {
 					break;
 				}
 				offset++;


### PR DESCRIPTION
We should check the line number before calling `lineAt`