### PR TITLE
Fix outFiles path

### DIFF
--- a/statusbar-sample/.vscode/launch.json
+++ b/statusbar-sample/.vscode/launch.json
@@ -13,7 +13,7 @@
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": [
-				"${workspaceRoot}/out/src/**/*.js"
+				"${workspaceRoot}/out/**/*.js"
 			],
 			"preLaunchTask": "npm: watch"
 		}


### PR DESCRIPTION
OutFiles are written to `<workspace>/out/*.js`. Fix this path to be able to debug again.