### PR TITLE
fix: lsp-embedded-language-serviceadd  add activationEvents to invoke  client

### DIFF
--- a/lsp-embedded-language-service/package.json
+++ b/lsp-embedded-language-service/package.json
@@ -14,7 +14,9 @@
 	"engines": {
 		"vscode": "^1.74.0"
 	},
-	"activationEvents": [],
+	"activationEvents": [
+		"onLanguage:html1"
+	],
 	"main": "./client/out/extension",
 	"contributes": {
 		"languages": [


### PR DESCRIPTION
##  What Happen?
it's seem that vscode high version can't work in lsp-embedded-language-service

## Why Happen?
i find some clues in [official document](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#explaining-the-language-client)
> Note: If your extension is compatible with VS Code versions prior to 1.74.0, you must declare onLanguage:plaintext in the [activationEvents](https://code.visualstudio.com/api/references/activation-events) field of /package.json to tell VS Code to activate the extension as soon as a plain text file is opened (for example a file with the extension .txt):

beacuse lack of activationEvents, it is origin activationEvents config
```
	"activationEvents": [],
```


## How to Fix?

```
	"activationEvents": [
		"onLanguage:html1"
	],
```

## Other
I've found that other people have the same problem

https://stackoverflow.com/questions/77038821/why-can-i-not-run-the-lsp-embedded-language-service-example-how-should-i-debug