### PR TITLE
webworker: the scope between the extension vs. test code is not shared

### DIFF
--- a/helloworld-test-sample/package.json
+++ b/helloworld-test-sample/package.json
@@ -11,7 +11,7 @@
 	"categories": [
 		"Other"
 	],
-	"activationEvents": [],
+	"activationEvents": ["onStartupFinished"],
 	"main": "./out/extension.js",
 	"contributes": {
 		"commands": [

--- a/helloworld-test-sample/src/extension.ts
+++ b/helloworld-test-sample/src/extension.ts
@@ -2,9 +2,15 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
+export let myGlobal = 'A';
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+	// Global variables are in the same scope/context as unit tests
+	// so this change will be reflected in unit tests
+	myGlobal = 'B';
+
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "helloworld-sample" is now active!');

--- a/helloworld-test-sample/src/test/suite/extension.test.ts
+++ b/helloworld-test-sample/src/test/suite/extension.test.ts
@@ -3,12 +3,15 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
+import { myGlobal } from '../../extension';
 // import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
 	test('Sample test', () => {
+		assert.strictEqual(myGlobal, 'C'); // This just works
+
 		assert.strictEqual([1, 2, 3].indexOf(5), -1);
 		assert.strictEqual([1, 2, 3].indexOf(0), -1);
 	});

--- a/helloworld-web-sample/.eslintrc.json
+++ b/helloworld-web-sample/.eslintrc.json
@@ -15,6 +15,7 @@
     "rules": {
         "@typescript-eslint/naming-convention": "warn",
         "@typescript-eslint/semi": "warn",
+        "@typescript-eslint/no-explicit-any": "off",
         "curly": "warn",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",

--- a/helloworld-web-sample/package.json
+++ b/helloworld-web-sample/package.json
@@ -13,7 +13,7 @@
 	"categories": [
 		"Other"
 	],
-	"activationEvents": [],
+	"activationEvents": ["onStartupFinished"],
 	"browser": "./dist/web/extension.js",
 	"contributes": {
 		"commands": [

--- a/helloworld-web-sample/src/web/extension.ts
+++ b/helloworld-web-sample/src/web/extension.ts
@@ -2,9 +2,17 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
+export let myGlobal = 'A';
+
 // This method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+	// This is in a different scope/context from the unit tests so this change will NOT
+	// be reflected in unit tests.
+	myGlobal = 'B';
+	// globalThis is shared between the extension and unit tests scope/contexts so this WILL
+	// be reflected in unit tests.
+	(globalThis as any).myOtherGlobal = 'C';
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated

--- a/helloworld-web-sample/src/web/test/suite/extension.test.ts
+++ b/helloworld-web-sample/src/web/test/suite/extension.test.ts
@@ -3,12 +3,16 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
+import { myGlobal } from '../../extension';
 // import * as myExtension from '../../extension';
 
 suite('Web Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
 	test('Sample test', () => {
+		assert.strictEqual((globalThis as any).myOtherGlobal, 'C'); // This is successful
+		assert.strictEqual(myGlobal, 'B'); // This fails when running unit tests in a Web context, but not in Node.js
+		
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});

--- a/helloworld-web-sample/src/web/test/suite/index.ts
+++ b/helloworld-web-sample/src/web/test/suite/index.ts
@@ -1,8 +1,9 @@
 // imports mocha for the browser, defining the `mocha` global.
 require('mocha/mocha');
+import * as vscode from 'vscode';
 
-export function run(): Promise<void> {
-
+export async function run(): Promise<void> {
+	await vscode.extensions.getExtension('vscode-samples.helloworld-web-sample')?.activate();
 	return new Promise((c, e) => {
 		mocha.setup({
 			ui: 'tdd',


### PR DESCRIPTION
In a node.js context, when running unit tests the context is shared between the extension and unit test code. This means that the state created in the extension context is the same as what the unit tests are using.

For example, defining a variable in the global scope of the extension code will be accessible by the unit tests.

---

But in a web extension, when running with webworkers this context is separate between the extension and unit tests. They only share the globalThis object from what I could find.

---

This commit displays these differences by showing in the unit tests that there is a disconnect in globally defined values in a web context.

In the `helloword-web-sample` I've added tests that show how global values are not shared between the extension and test executions, though `globalThis` is.

Similarily, in the `helloworld-test-sample` the tests show how a global value IS in the same context between the extension and test.