### PR TITLE
Couple AuthProvider Sample fixes

### DIFF
--- a/authenticationprovider-sample/src/authProvider.ts
+++ b/authenticationprovider-sample/src/authProvider.ts
@@ -26,7 +26,7 @@ class AzureDevOpsPatSession implements AuthenticationSession {
 }
 
 export class AzureDevOpsAuthenticationProvider implements AuthenticationProvider, Disposable {
-	static id = 'AzureDevOpsPAT';
+	static id = 'azuredevopspat';
 	private static secretKey = 'AzureDevOpsPAT';
 
 	// this property is used to determine if the token has been changed in another window of VS Code.
@@ -132,6 +132,11 @@ export class AzureDevOpsAuthenticationProvider implements AuthenticationProvider
 
 	// This function is called when the end user signs out of the account.
 	async removeSession(_sessionId: string): Promise<void> {
+		const token = await this.currentToken;
+		if (!token) {
+			return;
+		}
 		await this.secretStorage.delete(AzureDevOpsAuthenticationProvider.secretKey);
+		this._onDidChangeSessions.fire({ removed: [new AzureDevOpsPatSession(token)] });
 	}
 }

--- a/authenticationprovider-sample/src/extension.ts
+++ b/authenticationprovider-sample/src/extension.ts
@@ -12,8 +12,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register our authentication provider. NOTE: this will register the provider globally which means that
 	// any other extension can use this provider via the `getSession` API.
-	// NOTE: when implementing an auth provider, don't forget to register an activation event for that provider
-	// in your package.json file: "onAuthenticationRequest:AzureDevOpsPAT"
 	context.subscriptions.push(vscode.authentication.registerAuthenticationProvider(
 		AzureDevOpsAuthenticationProvider.id,
 		'Azure Repos',


### PR DESCRIPTION
1. remove comment about activation event, it doesn't apply anymore as we have implicit activation
2. aligned the ids
3. Fired removed change event which removes the account from the account menu

Fixes https://github.com/microsoft/vscode-extension-samples/issues/991