### PR TITLE
remove postinstall test provider

### DIFF
--- a/test-provider-sample/package.json
+++ b/test-provider-sample/package.json
@@ -21,9 +21,7 @@
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
 		"lint": "eslint \"src/**/*.ts\"",
-		"watch": "tsc -watch -p ./",
-		"postinstall": "npm run download-api",
-		"download-api": "npx @vscode/dts dev"
+		"watch": "tsc -watch -p ./"
 	},
 	"devDependencies": {
 		"@types/node": "^18",

--- a/test-provider-sample/package.json
+++ b/test-provider-sample/package.json
@@ -22,7 +22,8 @@
 		"compile": "tsc -p ./",
 		"lint": "eslint \"src/**/*.ts\"",
 		"watch": "tsc -watch -p ./",
-		"postinstall": "npm run download-api"
+		"postinstall": "npm run download-api",
+		"download-api": "npx @vscode/dts dev"
 	},
 	"devDependencies": {
 		"@types/node": "^18",


### PR DESCRIPTION
`npm i` fails in the `test-provider-sample` because it can't run its postinstall correctly.

cc: @connor4312 