### PR TITLE
fix: `lsp-embedded-language-service` cleaninterval args type

### DIFF
--- a/lsp-embedded-language-service/server/src/languageModelCache.ts
+++ b/lsp-embedded-language-service/server/src/languageModelCache.ts
@@ -15,7 +15,7 @@ export function getLanguageModelCache<T>(maxEntries: number, cleanupIntervalTime
 	let languageModels: Record</* uri */ string, { version: number, languageId: string, cTime: number, languageModel: T }> = {};
 	let nModels = 0;
 
-	let cleanupInterval: NodeJS.Timer | undefined = undefined;
+	let cleanupInterval: NodeJS.Timeout | undefined = undefined;
 	if (cleanupIntervalTimeInSec > 0) {
 		cleanupInterval = setInterval(() => {
 			const cutoffTime = Date.now() - cleanupIntervalTimeInSec * 1000;


### PR DESCRIPTION
Based on the @type/node version in the project，Parameter type of `clearInterval` is  

`NodeJS.Timeout | string | number | undefined`

When the parameter is `Nodejs.Timer` , The extension can't run