### PR TITLE
Add SHACL extension for RDF graphs

### DIFF
--- a/shacl-extension/README.md
+++ b/shacl-extension/README.md
@@ -1,0 +1,79 @@
+# SHACL Shapes Editor
+
+## Overview
+
+The SHACL Shapes Editor extension provides a user-friendly interface for authoring, creating, and editing SHACL Shapes for RDF graphs. SHACL (Shapes Constraint Language) is a language for validating RDF (Resource Description Framework) graphs against a set of conditions. This extension helps users to define and manage SHACL Shapes within Visual Studio Code.
+
+## Features
+
+- Create new SHACL Shapes
+- Edit existing SHACL Shapes
+- Visualize SHACL Shapes
+- Validate RDF graphs against SHACL Shapes
+
+## Installation
+
+1. Install Visual Studio Code.
+2. Open the Extensions view by clicking on the Extensions icon in the Activity Bar on the side of the window or by pressing `Ctrl+Shift+X`.
+3. Search for "SHACL Shapes Editor" and click Install.
+
+## Usage
+
+### Creating a SHACL Shape
+
+1. Open the Command Palette by pressing `Ctrl+Shift+P`.
+2. Type "Create SHACL Shape" and select the command.
+3. Enter the name of the SHACL Shape when prompted.
+4. A new document will open with the SHACL Shape definition in Turtle format.
+
+### Editing a SHACL Shape
+
+1. Open the SHACL Shape document you want to edit.
+2. Make the necessary changes to the SHACL Shape definition.
+3. Save the document.
+
+### Validating RDF Graphs
+
+1. Open the RDF graph document you want to validate.
+2. Open the SHACL Shape document you want to use for validation.
+3. Run the validation command from the Command Palette.
+
+## Examples
+
+### Example SHACL Shape
+
+```turtle
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+
+ex:PersonShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:property [
+        sh:path ex:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+    ] .
+```
+
+### Example RDF Graph
+
+```turtle
+@prefix ex: <http://example.org/> .
+
+ex:JohnDoe
+    a ex:Person ;
+    ex:name "John Doe" .
+```
+
+### Validating the RDF Graph
+
+To validate the RDF graph against the SHACL Shape, run the validation command from the Command Palette. The results will be displayed in the Output panel.
+
+## Contributing
+
+Contributions are welcome! Please read the [contributing guidelines](CONTRIBUTING.md) for more information.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/shacl-extension/package.json
+++ b/shacl-extension/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "shacl-extension",
+  "displayName": "SHACL Shapes Editor",
+  "description": "An extension for authoring, creating, and editing SHACL Shapes for RDF graphs.",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:shaclExtension.createShape"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "shaclExtension.createShape",
+        "title": "Create SHACL Shape"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile && npm run lint",
+    "lint": "eslint src --ext ts",
+    "test": "node ./out/test/runTest.js"
+  },
+  "devDependencies": {
+    "@types/node": "^14.14.37",
+    "@types/vscode": "^1.60.0",
+    "eslint": "^7.22.0",
+    "typescript": "^4.2.3",
+    "vscode-test": "^1.5.0"
+  },
+  "dependencies": {
+    "rdf-ext": "^2.0.0"
+  }
+}

--- a/shacl-extension/src/extension.ts
+++ b/shacl-extension/src/extension.ts
@@ -1,0 +1,100 @@
+import * as vscode from 'vscode';
+import * as rdf from 'rdf-ext';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function activate(context: vscode.ExtensionContext) {
+    const createShapeCommand = vscode.commands.registerCommand('shaclExtension.createShape', async () => {
+        const shapeName = await vscode.window.showInputBox({ prompt: 'Enter the name of the SHACL Shape' });
+        if (!shapeName) {
+            return;
+        }
+
+        const shape = rdf.namedNode(`http://example.org/${shapeName}`);
+        const shapeGraph = rdf.dataset();
+        shapeGraph.add(rdf.quad(shape, rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdf.namedNode('http://www.w3.org/ns/shacl#NodeShape')));
+
+        const shapeContent = shapeGraph.toString();
+        const shapeDocument = await vscode.workspace.openTextDocument({ content: shapeContent, language: 'turtle' });
+        await vscode.window.showTextDocument(shapeDocument);
+
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (workspaceFolders) {
+            const folderPath = workspaceFolders[0].uri.fsPath;
+            const filePath = path.join(folderPath, `${shapeName}.ttl`);
+            fs.writeFileSync(filePath, shapeContent);
+
+            const document = await vscode.workspace.openTextDocument(filePath);
+            const editor = await vscode.window.showTextDocument(document);
+
+            const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(event => {
+                if (event.document.uri.fsPath === filePath) {
+                    const updatedContent = event.document.getText();
+                    fs.writeFileSync(filePath, updatedContent);
+                }
+            });
+
+            context.subscriptions.push(changeDocumentSubscription);
+        }
+    });
+
+    context.subscriptions.push(createShapeCommand);
+
+    const validateGraphCommand = vscode.commands.registerCommand('shaclExtension.validateGraph', async () => {
+        const shapeDocument = await vscode.window.showOpenDialog({ filters: { 'Turtle Files': ['ttl'] } });
+        if (!shapeDocument || shapeDocument.length === 0) {
+            return;
+        }
+
+        const dataDocument = await vscode.window.showOpenDialog({ filters: { 'Turtle Files': ['ttl'] } });
+        if (!dataDocument || dataDocument.length === 0) {
+            return;
+        }
+
+        const shapeContent = fs.readFileSync(shapeDocument[0].fsPath, 'utf8');
+        const dataContent = fs.readFileSync(dataDocument[0].fsPath, 'utf8');
+
+        const shapeGraph = rdf.dataset().import(rdf.parse(shapeContent));
+        const dataGraph = rdf.dataset().import(rdf.parse(dataContent));
+
+        const validationReport = await rdf.validate(dataGraph, shapeGraph);
+
+        const validationResult = validationReport.conforms ? 'Validation successful!' : 'Validation failed!';
+        vscode.window.showInformationMessage(validationResult);
+
+        if (!validationReport.conforms) {
+            const annotations = validationReport.results.map(result => {
+                return {
+                    range: new vscode.Range(
+                        new vscode.Position(result.focusNode.line - 1, result.focusNode.column - 1),
+                        new vscode.Position(result.focusNode.line - 1, result.focusNode.column - 1 + result.focusNode.length)
+                    ),
+                    message: result.message,
+                    severity: vscode.DiagnosticSeverity.Error
+                };
+            });
+
+            const diagnosticCollection = vscode.languages.createDiagnosticCollection('shacl');
+            diagnosticCollection.set(dataDocument[0], annotations);
+            context.subscriptions.push(diagnosticCollection);
+        }
+    });
+
+    context.subscriptions.push(validateGraphCommand);
+
+    const showFocusNodesCommand = vscode.commands.registerCommand('shaclExtension.showFocusNodes', async () => {
+        const shapeDocument = await vscode.window.showOpenDialog({ filters: { 'Turtle Files': ['ttl'] } });
+        if (!shapeDocument || shapeDocument.length === 0) {
+            return;
+        }
+
+        const shapeContent = fs.readFileSync(shapeDocument[0].fsPath, 'utf8');
+        const shapeGraph = rdf.dataset().import(rdf.parse(shapeContent));
+
+        const focusNodes = shapeGraph.match(null, rdf.namedNode('http://www.w3.org/ns/shacl#targetClass')).toArray().map(quad => quad.subject.value);
+
+        vscode.window.showQuickPick(focusNodes, { placeHolder: 'Select a focus node' });
+    });
+
+    context.subscriptions.push(showFocusNodesCommand);
+}


### PR DESCRIPTION
Add a new SHACL Shapes Editor extension for authoring, creating, and editing SHACL Shapes for RDF graphs.

* **shacl-extension/src/extension.ts**
  - Import necessary modules from `vscode`, `rdf-ext`, `fs`, and `path`.
  - Define and register a command for creating SHACL Shapes.
  - Implement functionality to create a new SHACL Shape and sync changes with the underlying `.ttl` file.
  - Define and register a command for validating RDF graphs against SHACL Shapes.
  - Implement functionality to validate RDF graphs and visually annotate violations.
  - Define and register a command to show all focus nodes of a selected SHACL Shape.

* **shacl-extension/package.json**
  - Add metadata for the new SHACL extension.
  - Define the new commands in the `contributes` section.
  - Specify the activation events for the extension.
  - Add necessary dependencies and scripts for the extension.

* **shacl-extension/README.md**
  - Provide an overview of the SHACL Shapes Editor extension.
  - Include instructions for creating, editing, and validating SHACL Shapes.
  - Add examples of SHACL Shapes and RDF graphs.

