### PR TITLE
Add canBeReferencedInPrompt property to tools

### DIFF
--- a/chat-sample/package.json
+++ b/chat-sample/package.json
@@ -97,6 +97,7 @@
 				"toolReferenceName": "tabCount",
 				"displayName": "Tab Count",
 				"modelDescription": "The number of active tabs in a tab group",
+				"canBeReferencedInPrompt": true,
 				"icon": "$(files)",
 				"inputSchema": {
 					"type": "object",
@@ -118,6 +119,7 @@
 				],
 				"displayName": "Find Files",
 				"modelDescription": "Search for files in the current workspace",
+				"canBeReferencedInPrompt": true,
 				"inputSchema": {
 					"type": "object",
 					"properties": {
@@ -139,6 +141,7 @@
 				],
 				"displayName": "Run in Terminal",
 				"modelDescription": "Run a command in a terminal and return the output",
+				"canBeReferencedInPrompt": false,
 				"inputSchema": {
 					"type": "object",
 					"properties": {

--- a/chat-sample/package.json
+++ b/chat-sample/package.json
@@ -94,7 +94,7 @@
 					"editors",
 					"chat-tools-sample"
 				],
-				"toolReferenceName": "tabCount",
+				"toolReferenceName": "countTabs",
 				"displayName": "Tab Count",
 				"modelDescription": "The number of active tabs in a tab group",
 				"canBeReferencedInPrompt": true,
@@ -117,6 +117,7 @@
 					"search",
 					"chat-tools-sample"
 				],
+				"toolReferenceName": "findFiles",
 				"displayName": "Find Files",
 				"modelDescription": "Search for files in the current workspace",
 				"canBeReferencedInPrompt": true,


### PR DESCRIPTION
I do not want runInTerminal to be confused with our built-in agent tool so I put canBeReferencedInPrompt to false.
The other two I put true.

Users should easily see this behaviour since it the main use case of tools is being used in agent mode