### PR TITLE
Attempt to build unified extension.ts for browser/node

### DIFF
--- a/wasm-language-server/bin/esbuild.js
+++ b/wasm-language-server/bin/esbuild.js
@@ -16,6 +16,9 @@ const sharedWebOptions = {
 	target: 'es2020',
 	platform: 'browser',
 	sourcemap: true,
+	define: {
+        'IS_DESKTOP': 'false'
+    }
 };
 
 /** @type BuildOptions */
@@ -33,12 +36,15 @@ const sharedDesktopOptions = {
 	target: 'es2020',
 	platform: 'node',
 	sourcemap: true,
+	define: {
+        'IS_DESKTOP': 'true'
+    }
 };
 
 /** @type BuildOptions */
 const desktopOptions = {
 	entryPoints: ['client/src/extension.ts'],
-	outfile: 'client/dist/desktop/extension.js',
+	outfile: 'client/out/extension.js',
 	format: 'cjs',
 	...sharedDesktopOptions,
 };

--- a/wasm-language-server/client/bin/esbuild.js
+++ b/wasm-language-server/client/bin/esbuild.js
@@ -16,6 +16,9 @@ const sharedWebOptions = {
 	target: 'es2020',
 	platform: 'browser',
 	sourcemap: true,
+	define: {
+        'IS_DESKTOP': 'false'
+	}
 };
 
 /** @type BuildOptions */
@@ -33,12 +36,15 @@ const sharedDesktopOptions = {
 	target: 'es2020',
 	platform: 'node',
 	sourcemap: true,
+	define: {
+        'IS_DESKTOP': 'true'
+	}
 };
 
 /** @type BuildOptions */
 const desktopOptions = {
 	entryPoints: ['src/extension.ts'],
-	outfile: 'dist/desktop/extension.js',
+	outfile: 'out/extension.js',
 	format: 'cjs',
 	...sharedDesktopOptions,
 };

--- a/wasm-language-server/client/package.json
+++ b/wasm-language-server/client/package.json
@@ -29,9 +29,9 @@
 		"@types/node": "^22"
 	},
 	"scripts": {
-		"compile": "tsc -b",
+		"compile": "npm run esbuild",
 		"watch": "tsc -b -w",
 		"lint": "eslint",
-		"esbuild": "^0.25.0"
+		"esbuild": "node ./bin/esbuild.js"
 	}
 }

--- a/wasm-language-server/client/src/extension.ts
+++ b/wasm-language-server/client/src/extension.ts
@@ -3,8 +3,17 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+// declared in esbuild.js
+declare const IS_DESKTOP: boolean;
+
 import { ExtensionContext, Uri, window, workspace, commands } from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions, RequestType } from 'vscode-languageclient/node';
+import { LanguageClient, LanguageClientOptions, ServerOptions, RequestType } from 'vscode-languageclient';
+if (IS_DESKTOP) {
+	require('vscode-languageclient/node');
+} else {
+	require('vscode-languageclient/browser');
+}
+
 import { Wasm, ProcessOptions } from '@vscode/wasm-wasi/v1';
 import { createStdioOptions, createUriConverters, startServer } from '@vscode/wasm-wasi-lsp';
 


### PR DESCRIPTION
This is an attempt to fix #1230 without duplicating the extension.ts file and fiddling with the import statement.
I'm pretty ignorant of javascript but this seemed to work for building both the desktop and web versions.