### PR TITLE
fix: chat-model-provider-sample vscode version in package.json

### DIFF
--- a/chat-model-provider-sample/package.json
+++ b/chat-model-provider-sample/package.json
@@ -9,7 +9,7 @@
 	},
 	"version": "0.1.0",
 	"engines": {
-		"vscode": "^1.104"
+		"vscode": "^1.104.0"
 	},
 	"categories": [
 		"AI",


### PR DESCRIPTION
Just a small fix to the package.json.

The following error occurs when running chat-model-provider-sample:

> Failed loading extension '~/vscode-extension-samples/chat-model-provider-sample' under development because it is invalid: Could not parse `engines.vscode` value ^1.104. Please use, for example: ^1.22.0, ^1.22.x, etc.
