### PR TITLE
Replace deprecated typescript.tsc.autoDetect setting

### DIFF
--- a/authenticationprovider-sample/.vscode/settings.json
+++ b/authenticationprovider-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }

--- a/basic-multi-root-sample/.vscode/settings.json
+++ b/basic-multi-root-sample/.vscode/settings.json
@@ -6,5 +6,5 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "typescript.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
+    "js/ts.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
 }

--- a/chat-context-sample/.vscode/settings.json
+++ b/chat-context-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
 		"out": true // set this to false to include "out" folder in search results
 	},
 	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-	"typescript.tsc.autoDetect": "off"
+	"js/ts.tsc.autoDetect": "off"
 }

--- a/chat-tutorial/.vscode/settings.json
+++ b/chat-tutorial/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }

--- a/configuration-sample/.vscode/settings.json
+++ b/configuration-sample/.vscode/settings.json
@@ -7,6 +7,6 @@
         "out": true // set this to false to include "out" folder in search results
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "typescript.tsc.autoDetect": "off",
+    "js/ts.tsc.autoDetect": "off",
     "editor.insertSpaces": false,
 }

--- a/jupyter-kernel-execution-sample/.vscode/settings.json
+++ b/jupyter-kernel-execution-sample/.vscode/settings.json
@@ -2,5 +2,5 @@
   "search.exclude": {
     "out": true
   },
-  "typescript.tsc.autoDetect": "off"
+  "js/ts.tsc.autoDetect": "off"
 }

--- a/jupyter-server-provider-sample/.vscode/settings.json
+++ b/jupyter-server-provider-sample/.vscode/settings.json
@@ -2,5 +2,5 @@
   "search.exclude": {
     "out": true
   },
-  "typescript.tsc.autoDetect": "off"
+  "js/ts.tsc.autoDetect": "off"
 }

--- a/l10n-sample/.vscode/settings.json
+++ b/l10n-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }

--- a/lm-api-tutorial/.vscode/settings.json
+++ b/lm-api-tutorial/.vscode/settings.json
@@ -7,5 +7,5 @@
 		"out": true // set this to false to include "out" folder in search results
 	},
 	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-	"typescript.tsc.autoDetect": "off"
+	"js/ts.tsc.autoDetect": "off"
 }

--- a/lsp-embedded-language-service/.vscode/settings.json
+++ b/lsp-embedded-language-service/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
 	"editor.insertSpaces": false,
-	"typescript.tsc.autoDetect": "off",
+	"js/ts.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single"
 }

--- a/lsp-embedded-request-forwarding/.vscode/settings.json
+++ b/lsp-embedded-request-forwarding/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
 	"editor.insertSpaces": false,
-	"typescript.tsc.autoDetect": "off",
+	"js/ts.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single"
 }

--- a/lsp-multi-server-sample/.vscode/settings.json
+++ b/lsp-multi-server-sample/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
 	"editor.insertSpaces": false,
-	"typescript.tsc.autoDetect": "off",
+	"js/ts.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single"
 }

--- a/lsp-sample/.vscode/settings.json
+++ b/lsp-sample/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
 	"editor.insertSpaces": false,
-	"typescript.tsc.autoDetect": "off",
+	"js/ts.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single",
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"

--- a/lsp-user-input-sample/.vscode/settings.json
+++ b/lsp-user-input-sample/.vscode/settings.json
@@ -11,7 +11,7 @@
 	"editor.insertSpaces": false,
 	"editor.tabSize": 4,
 	"typescript.tsdk": "./node_modules/typescript/lib",
-	"typescript.tsc.autoDetect": "off",
+	"js/ts.tsc.autoDetect": "off",
 	"eslint.enable": true,
 	"eslint.validate": [
 		"typescript"

--- a/lsp-web-extension-sample/.vscode/settings.json
+++ b/lsp-web-extension-sample/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
 	"editor.insertSpaces": false,
-	"typescript.tsc.autoDetect": "off",
+	"js/ts.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single",
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"

--- a/nodefs-provider-sample/.vscode/settings.json
+++ b/nodefs-provider-sample/.vscode/settings.json
@@ -6,5 +6,5 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "typescript.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
+    "js/ts.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
 }

--- a/notebook-extend-markdown-renderer-sample/.vscode/settings.json
+++ b/notebook-extend-markdown-renderer-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
     "out": true // set this to false to include "out" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "js/ts.tsc.autoDetect": "off"
 }

--- a/notebook-format-code-action-sample/.vscode/settings.json
+++ b/notebook-format-code-action-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }

--- a/notebook-renderer-react-sample/.vscode/settings.json
+++ b/notebook-renderer-react-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
     "out": true // set this to false to include "out" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "js/ts.tsc.autoDetect": "off"
 }

--- a/notebook-renderer-sample/.vscode/settings.json
+++ b/notebook-renderer-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
     "out": true // set this to false to include "out" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "js/ts.tsc.autoDetect": "off"
 }

--- a/notebook-serializer-sample/.vscode/settings.json
+++ b/notebook-serializer-sample/.vscode/settings.json
@@ -2,5 +2,5 @@
   "search.exclude": {
     "out": true
   },
-  "typescript.tsc.autoDetect": "off"
+  "js/ts.tsc.autoDetect": "off"
 }

--- a/notifications-sample/.vscode/settings.json
+++ b/notifications-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }

--- a/progress-sample/.vscode/settings.json
+++ b/progress-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
 		"out": true // set this to false to include "out" folder in search results
 	},
 	"typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-	"typescript.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
+	"js/ts.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
 }

--- a/quickinput-sample/.vscode/settings.json
+++ b/quickinput-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }

--- a/shell-integration-sample/.vscode/settings.json
+++ b/shell-integration-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }

--- a/statusbar-sample/.vscode/settings.json
+++ b/statusbar-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
 		"out": true // set this to false to include "out" folder in search results
 	},
 	"typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-	"typescript.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
+	"js/ts.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
 }

--- a/task-provider-sample/.vscode/settings.json
+++ b/task-provider-sample/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
 	"editor.insertSpaces": false,
-	"typescript.tsc.autoDetect": "off",
+	"js/ts.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single"
 }

--- a/tree-view-sample/.vscode/settings.json
+++ b/tree-view-sample/.vscode/settings.json
@@ -7,6 +7,6 @@
         "out": true // set this to false to include "out" folder in search results
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "typescript.tsc.autoDetect": "off",
+    "js/ts.tsc.autoDetect": "off",
     "editor.insertSpaces": false,
 }

--- a/uri-handler-sample/.vscode/settings.json
+++ b/uri-handler-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }

--- a/virtual-document-sample/.vscode/settings.json
+++ b/virtual-document-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
 		"out": true // set this to false to include "out" folder in search results
 	},
 	"typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-	"typescript.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
+	"js/ts.tsc.autoDetect": "off" // Turn off tsc task auto detection since we have the necessary task as npm scripts
 }

--- a/welcome-view-content-sample/.vscode/settings.json
+++ b/welcome-view-content-sample/.vscode/settings.json
@@ -7,5 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "js/ts.tsc.autoDetect": "off"
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `typescript.tsc.autoDetect` with `js/ts.tsc.autoDetect` across 31 sample workspaces.
- Aligns sample settings with VS Code 1.110 setting rename.

Fixes #1285

## Test plan
- [x] Verified all 31 affected `.vscode/settings.json` files use `js/ts.tsc.autoDetect`
- [x] Confirmed no remaining references to `typescript.tsc.autoDetect` in the repository