### PR TITLE
Fix FTP explorer subdirectory file retrieval (#1155)

### DIFF
--- a/tree-view-sample/src/ftpExplorer.ts
+++ b/tree-view-sample/src/ftpExplorer.ts
@@ -42,7 +42,7 @@ export class FtpModel {
 
 					client.end();
 
-					return c(this.sort(list.map(entry => ({ resource: vscode.Uri.parse(`ftp://${this.host}///${entry.name}`), isDirectory: entry.type === 'd' }))));
+					return c(this.sort(list.map(entry => ({ resource: vscode.Uri.parse(`ftp://${this.host}//${entry.name}`), isDirectory: entry.type === 'd' }))));
 				});
 			});
 		});
@@ -58,7 +58,12 @@ export class FtpModel {
 
 					client.end();
 
-					return c(this.sort(list.map(entry => ({ resource: vscode.Uri.parse(`${node.resource.fsPath}/${entry.name}`), isDirectory: entry.type === 'd' }))));
+					return c(this.sort(list.map(entry => {
+						const path = node.resource.path.endsWith('/')
+							? `${node.resource.path}${entry.name}`
+							: `${node.resource.path}/${entry.name}`;
+						return { resource: node.resource.with({ path }), isDirectory: entry.type === 'd' };
+					})));
 				});
 			});
 		});
@@ -81,7 +86,7 @@ export class FtpModel {
 	public getContent(resource: vscode.Uri): Thenable<string> {
 		return this.connect().then(client => {
 			return new Promise((c, e) => {
-				client.get(resource.path.substr(2), (err, stream) => {
+				client.get(resource.path.substr(1), (err, stream) => {
 					if (err) {
 						return e(err);
 					}
@@ -148,7 +153,7 @@ export class FtpExplorer {
 
 	constructor(context: vscode.ExtensionContext) {
 		/* Please note that login information is hardcoded only for this example purpose and recommended not to do it in general. */
-		const ftpModel = new FtpModel('mirror.switch.ch', 'anonymous', 'anonymous@anonymous.de');
+		const ftpModel = new FtpModel('test.rebex.net', 'anonymous', 'anonymous@anonymous.de');
 		const treeDataProvider = new FtpTreeDataProvider(ftpModel);
 		context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('ftp', treeDataProvider));
 


### PR DESCRIPTION
## Summary
- Build root FTP URIs with \//\ instead of \///\ so paths stay well-formed
- Preserve the \tp\ scheme when creating child URIs via \esource.with()\ instead of \Uri.parse(fsPath)\
- Use \substr(1)\ in \getContent\ so nested paths like \/pub/example/readme.txt\ resolve correctly
- Switch the demo FTP server to \	est.rebex.net\ because \mirror.switch.ch\ is no longer available

Fixes #1155

## Test plan
- [x] \
pm run compile\ in \	ree-view-sample\
- [ ] Press F5 in \	ree-view-sample\, open FTP Explorer, navigate to \/pub/example\, and open \eadme.txt\


Made with [Cursor](https://cursor.com)